### PR TITLE
Some fixes

### DIFF
--- a/dsl/static/src/ContextUtils.kt
+++ b/dsl/static/src/ContextUtils.kt
@@ -23,6 +23,7 @@ import android.content.ActivityNotFoundException
 import android.preference.PreferenceManager
 import android.app.Activity
 import android.app.Fragment
+import android.app.Service
 import android.os.Bundle
 import android.net.Uri
 import java.io.Serializable
@@ -214,6 +215,11 @@ public inline fun <reified T: Activity> Fragment.startActivity(vararg params: Pa
 [suppress("NOTHING_TO_INLINE")]
 public inline fun <reified T: Activity> Fragment.startActivityForResult(requestCode: Int, vararg params: Pair<String, Any>) {
     AnkoInternals.internalStartActivityForResult(getActivity(), javaClass<T>(), requestCode, params)
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun <reified T: Service> Context.startService(vararg params: Pair<String, Any>) {
+    AnkoInternals.internalStartService(this, javaClass<T>(), params)
 }
 
 public fun <T: Fragment> T.withArguments(vararg params: Pair<String, Any>): T {

--- a/dsl/static/src/ContextUtils.kt
+++ b/dsl/static/src/ContextUtils.kt
@@ -222,6 +222,11 @@ public inline fun <reified T: Service> Context.startService(vararg params: Pair<
     AnkoInternals.internalStartService(this, javaClass<T>(), params)
 }
 
+[suppress("NOTHING_TO_INLINE")]
+public inline fun <reified T: Service> Fragment.startService(vararg params: Pair<String, Any>) {
+    AnkoInternals.internalStartService(getActivity(), javaClass<T>(), params)
+}
+
 public fun <T: Fragment> T.withArguments(vararg params: Pair<String, Any>): T {
     setArguments(bundleOf(*params))
     return this

--- a/dsl/static/src/Database.kt
+++ b/dsl/static/src/Database.kt
@@ -27,6 +27,8 @@ import android.content.Context
 import org.jetbrains.anko.internals.AnkoInternals
 
 public val NULL: SqlType = SqlTypeImpl("NULL")
+deprecated("Use INTEGER instead")
+public val INT: SqlType = SqlTypeImpl("INT")
 public val INTEGER: SqlType = SqlTypeImpl("INTEGER")
 public val REAL: SqlType = SqlTypeImpl("REAL")
 public val TEXT: SqlType = SqlTypeImpl("TEXT")

--- a/dsl/static/src/Database.kt
+++ b/dsl/static/src/Database.kt
@@ -27,7 +27,7 @@ import android.content.Context
 import org.jetbrains.anko.internals.AnkoInternals
 
 public val NULL: SqlType = SqlTypeImpl("NULL")
-public val INT: SqlType = SqlTypeImpl("INT")
+public val INTEGER: SqlType = SqlTypeImpl("INTEGER")
 public val REAL: SqlType = SqlTypeImpl("REAL")
 public val TEXT: SqlType = SqlTypeImpl("TEXT")
 public val BLOB: SqlType = SqlTypeImpl("BLOB")

--- a/dsl/static/src/Internals.kt
+++ b/dsl/static/src/Internals.kt
@@ -18,6 +18,7 @@ package org.jetbrains.anko.internals
 
 import android.content.Context
 import android.app.Activity
+import android.app.Service
 import android.app.UiModeManager
 import android.content.Intent
 import android.content.res.Configuration
@@ -77,6 +78,15 @@ public object AnkoInternals {
             params: Array<out Pair<String, Any>>
     ) {
         act.startActivityForResult(createIntent(act, activity, params), requestCode)
+    }
+
+    platformStatic
+    public fun internalStartService(
+            ctx: Context,
+            activity: Class<out Service>,
+            params: Array<out Pair<String, Any>>
+    ) {
+        ctx.startService(createIntent(ctx, activity, params))
     }
 
     platformStatic

--- a/dsl/static/src/Support.kt
+++ b/dsl/static/src/Support.kt
@@ -18,6 +18,7 @@ package org.jetbrains.anko
 
 import android.app.Activity
 import android.app.ProgressDialog
+import android.app.Service
 import android.support.v4.app.Fragment
 import android.view.View
 import android.widget.LinearLayout
@@ -95,6 +96,11 @@ public inline fun <reified T: Activity> Fragment.startActivity(vararg params: Pa
 [suppress("NOTHING_TO_INLINE")]
 public inline fun <reified T: Activity> Fragment.startActivityForResult(requestCode: Int, vararg params: Pair<String, Any>) {
     AnkoInternals.internalStartActivityForResult(getActivity(), javaClass<T>(), requestCode, params)
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun <reified T: Service> Fragment.startService(vararg params: Pair<String, Any>) {
+    AnkoInternals.internalStartService(getActivity(), javaClass<T>(), params)
 }
 
 public inline fun <reified T: Any> Fragment.intentFor(): Intent = Intent(getActivity(), javaClass<T>())


### PR DESCRIPTION
1. ([Commit 1](https://github.com/lucky-dev/anko/commit/6d9ecb5e4b6dd34e7e605300f7beecfa28ddaade)) The method "startService" was added to Context. It gives opportunity to write code like this:

```java
context.startService<MyService>("id" to 1)
```

2. ([Commit 2](https://github.com/lucky-dev/anko/commit/3f8dcca99672eac4fd7b2e7351a898468a67e393)) I found this bug:
```
E/SQLiteLog﹕ (1) AUTOINCREMENT is only allowed on an INTEGER PRIMARY KEY
```
when I was creating a table
```java
createTable(MyTable.NAME, false,
                        MyTable.Column.ID to INT + PRIMARY_KEY + AUTOINCREMENT,
                        MyTable.Column.NAME to TEXT)
```
