### PR TITLE
Fixed include() return type

### DIFF
--- a/dsl/static/src/Other.kt
+++ b/dsl/static/src/Other.kt
@@ -83,7 +83,7 @@ public inline fun Fragment.verticalLayout(inlineOptions(InlineOption.ONLY_LOCAL_
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun <T: View> ViewManager.include(layoutId: Int): LinearLayout = include(layoutId, {})
+public inline fun <T: View> ViewManager.include(layoutId: Int): T = include(layoutId, {})
 public inline fun <T: View> ViewManager.include(layoutId: Int, inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: T.() -> Unit): T = addView { ctx ->
     [suppress("UNCHECKED_CAST")]
     val view = ctx.layoutInflater.inflate(layoutId, null) as T
@@ -92,7 +92,7 @@ public inline fun <T: View> ViewManager.include(layoutId: Int, inlineOptions(Inl
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun <T: View> Activity.include(layoutId: Int): LinearLayout = include(layoutId, {})
+public inline fun <T: View> Activity.include(layoutId: Int): T = include(layoutId, {})
 public inline fun <T: View> Activity.include(layoutId: Int, inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: T.() -> Unit): T = addView { ctx ->
     [suppress("UNCHECKED_CAST")]
     val view = ctx.layoutInflater.inflate(layoutId, null) as T
@@ -101,7 +101,7 @@ public inline fun <T: View> Activity.include(layoutId: Int, inlineOptions(Inline
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun <T: View> Fragment.include(layoutId: Int): LinearLayout = include(layoutId, {})
+public inline fun <T: View> Fragment.include(layoutId: Int): T = include(layoutId, {})
 public inline fun <T: View> Fragment.include(layoutId: Int, inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: T.() -> Unit): T = addView { ctx ->
     [suppress("UNCHECKED_CAST")]
     val view = ctx.layoutInflater.inflate(layoutId, null) as T
@@ -110,7 +110,7 @@ public inline fun <T: View> Fragment.include(layoutId: Int, inlineOptions(Inline
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun <T: View> Context.include(layoutId: Int): LinearLayout = include(layoutId, {})
+public inline fun <T: View> Context.include(layoutId: Int): T = include(layoutId, {})
 public inline fun <T: View> Context.include(layoutId: Int, inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: T.() -> Unit): T = addView { ctx ->
     [suppress("UNCHECKED_CAST")]
     val view = ctx.layoutInflater.inflate(layoutId, null) as T


### PR DESCRIPTION
In include(layoutId: Int), the inflated view was casted to LinearLayout which results in ClassCastException.