### PR TITLE
Smarter LayoutParams extraction

### DIFF
--- a/dsl/src/org/jetbrains/android/anko/utils/ClassInfo.kt
+++ b/dsl/src/org/jetbrains/android/anko/utils/ClassInfo.kt
@@ -73,6 +73,11 @@ fun ClassNode.getConstructors(): List<MethodNode> {
     return (methods as List<MethodNode>).filter { it.isConstructor }
 }
 
+fun ClassNode.isLayoutParams(classTree: ClassTree): Boolean {
+    val isSuccessor = classTree.isSuccessorOf(this, "android/view/ViewGroup\$LayoutParams") || this.name == "android/view/ViewGroup\$LayoutParams"
+    return isSuccessor && isInner
+}
+
 fun ClassNode.isView(classTree: ClassTree): Boolean {
     val isSuccessor = classTree.isSuccessorOf(this, "android/view/View") || this.name == "android/view/View"
     return isSuccessor && !isInner

--- a/dsl/testData/compile/AndroidLayoutParamsTest.kt
+++ b/dsl/testData/compile/AndroidLayoutParamsTest.kt
@@ -5,7 +5,7 @@ import android.os.Bundle
 import org.jetbrains.anko.*
 import android.widget.LinearLayout
 import android.widget.RelativeLayout
-import android.widget.AbsoluteLayout
+import android.widget.ScrollView
 import android.widget.FrameLayout
 import android.widget.GridLayout
 import android.view.Gravity
@@ -41,12 +41,15 @@ public open class MyActivity() : Activity() {
                     }
                 }
             }
-            absoluteLayout {
+            scrollView {
                 editText {
-                    layoutParams(-2, -2, 12, 23) {
+                    layoutParams(-2, -2) {
+                        bottomMargin = 1
+                        leftMargin = 2
+                        rightMargin = 3
+                        topMargin = 4
                         height = 9
-                        x = 100
-                        y = 200
+                        gravity = Gravity.RIGHT
                     }
                 }
             }

--- a/dsl/testData/functional/15/LayoutsTest.kt
+++ b/dsl/testData/functional/15/LayoutsTest.kt
@@ -36,48 +36,145 @@ public open class _AppWidgetHostView(ctx: Context): android.appwidget.AppWidgetH
 
 }
 
-public open class _WebView(ctx: Context): android.webkit.WebView(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, webViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
-        layoutParams.webViewInit()
+public open class _GestureOverlayView(ctx: Context): android.gesture.GestureOverlayView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.gestureOverlayViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, webViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
-        layoutParams.webViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.gestureOverlayViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, webViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
-        layoutParams.webViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.gestureOverlayViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.gestureOverlayViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.gestureOverlayViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
 }
 
-public open class _AbsoluteLayout(ctx: Context): android.widget.AbsoluteLayout(ctx) {
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, x: Int, y: Int, absoluteLayoutInit: android.widget.AbsoluteLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.AbsoluteLayout.LayoutParams(width, height, x, y)
-        layoutParams.absoluteLayoutInit()
+public open class _CalendarView(ctx: Context): android.widget.CalendarView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.calendarViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, absoluteLayoutInit: android.widget.AbsoluteLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.AbsoluteLayout.LayoutParams(c!!, attrs!!)
-        layoutParams.absoluteLayoutInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.calendarViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, absoluteLayoutInit: android.widget.AbsoluteLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.AbsoluteLayout.LayoutParams(source!!)
-        layoutParams.absoluteLayoutInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.calendarViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.calendarViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.calendarViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _DatePicker(ctx: Context): android.widget.DatePicker(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _DialerFilter(ctx: Context): android.widget.DialerFilter(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, dialerFilterInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.dialerFilterInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, dialerFilterInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(width, height)
+        layoutParams.dialerFilterInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, dialerFilterInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.dialerFilterInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, dialerFilterInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.dialerFilterInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -116,30 +213,6 @@ public open class _FrameLayout(ctx: Context): android.widget.FrameLayout(ctx) {
     public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, frameLayoutInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
         val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
         layoutParams.frameLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-}
-
-public open class _Gallery(ctx: Context): android.widget.Gallery(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, galleryInit: android.widget.Gallery.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.Gallery.LayoutParams(c!!, attrs!!)
-        layoutParams.galleryInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, galleryInit: android.widget.Gallery.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.Gallery.LayoutParams(width, height)
-        layoutParams.galleryInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, galleryInit: android.widget.Gallery.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.Gallery.LayoutParams(source!!)
-        layoutParams.galleryInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -191,48 +264,76 @@ public open class _GridLayout(ctx: Context): android.widget.GridLayout(ctx) {
 
 }
 
-public open class _GridView(ctx: Context): android.widget.GridView(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, gridViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
-        layoutParams.gridViewInit()
+public open class _HorizontalScrollView(ctx: Context): android.widget.HorizontalScrollView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.horizontalScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gridViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
-        layoutParams.gridViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.horizontalScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, gridViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
-        layoutParams.gridViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.horizontalScrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.horizontalScrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.horizontalScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
 }
 
-public open class _HorizontalScrollView(ctx: Context): android.widget.HorizontalScrollView(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, horizontalScrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
-        layoutParams.horizontalScrollViewInit()
+public open class _ImageSwitcher(ctx: Context): android.widget.ImageSwitcher(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.imageSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, horizontalScrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
-        layoutParams.horizontalScrollViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.imageSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, horizontalScrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
-        layoutParams.horizontalScrollViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.imageSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.imageSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.imageSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -271,6 +372,44 @@ public open class _LinearLayout(ctx: Context): android.widget.LinearLayout(ctx) 
     public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, linearLayoutInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
         val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
         layoutParams.linearLayoutInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _NumberPicker(ctx: Context): android.widget.NumberPicker(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.numberPickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height)
+        layoutParams.numberPickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, weight: Float, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height, weight)
+        layoutParams.numberPickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(p: android.view.ViewGroup.LayoutParams?, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(p!!)
+        layoutParams.numberPickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.numberPickerInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -347,23 +486,151 @@ public open class _RelativeLayout(ctx: Context): android.widget.RelativeLayout(c
 }
 
 public open class _ScrollView(ctx: Context): android.widget.ScrollView(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, scrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
         layoutParams.scrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, scrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
         layoutParams.scrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, scrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
         layoutParams.scrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.scrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.scrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _SearchView(ctx: Context): android.widget.SearchView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, weight: Float, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height, weight)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(p: android.view.ViewGroup.LayoutParams?, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(p!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _TabHost(ctx: Context): android.widget.TabHost(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _TabWidget(ctx: Context): android.widget.TabWidget(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.tabWidgetInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height)
+        layoutParams.tabWidgetInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, weight: Float, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height, weight)
+        layoutParams.tabWidgetInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(p: android.view.ViewGroup.LayoutParams?, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(p!!)
+        layoutParams.tabWidgetInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.tabWidgetInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -468,23 +735,106 @@ public open class _TableRow(ctx: Context): android.widget.TableRow(ctx) {
 }
 
 public open class _TextSwitcher(ctx: Context): android.widget.TextSwitcher(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, textSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
         layoutParams.textSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, textSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
         layoutParams.textSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, textSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
         layoutParams.textSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.textSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.textSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _TimePicker(ctx: Context): android.widget.TimePicker(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _TwoLineListItem(ctx: Context): android.widget.TwoLineListItem(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, twoLineListItemInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.twoLineListItemInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, twoLineListItemInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(width, height)
+        layoutParams.twoLineListItemInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, twoLineListItemInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.twoLineListItemInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, twoLineListItemInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.twoLineListItemInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -492,22 +842,36 @@ public open class _TextSwitcher(ctx: Context): android.widget.TextSwitcher(ctx) 
 }
 
 public open class _ViewAnimator(ctx: Context): android.widget.ViewAnimator(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewAnimatorInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
         layoutParams.viewAnimatorInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewAnimatorInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
         layoutParams.viewAnimatorInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewAnimatorInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.viewAnimatorInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewAnimatorInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
         layoutParams.viewAnimatorInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
@@ -515,24 +879,114 @@ public open class _ViewAnimator(ctx: Context): android.widget.ViewAnimator(ctx) 
 
 }
 
+public open class _ViewFlipper(ctx: Context): android.widget.ViewFlipper(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
 public open class _ViewSwitcher(ctx: Context): android.widget.ViewSwitcher(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
         layoutParams.viewSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
         layoutParams.viewSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
         layoutParams.viewSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _ZoomControls(ctx: Context): android.widget.ZoomControls(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.zoomControlsInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height)
+        layoutParams.zoomControlsInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, weight: Float, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height, weight)
+        layoutParams.zoomControlsInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(p: android.view.ViewGroup.LayoutParams?, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(p!!)
+        layoutParams.zoomControlsInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.zoomControlsInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }

--- a/dsl/testData/functional/15/ViewTest.kt
+++ b/dsl/testData/functional/15/ViewTest.kt
@@ -1,31 +1,4 @@
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
-public inline fun ViewManager.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.gesture.GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
-    ctx ->
-    val view = android.gesture.GestureOverlayView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
-public inline fun Context.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.gesture.GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
-    ctx ->
-    val view = android.gesture.GestureOverlayView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
-public inline fun Activity.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.gesture.GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
-    ctx ->
-    val view = android.gesture.GestureOverlayView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.extractEditText(): android.inputmethodservice.ExtractEditText = extractEditText({})
 public inline fun ViewManager.extractEditText(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.inputmethodservice.ExtractEditText.() -> Unit): android.inputmethodservice.ExtractEditText = addView<android.inputmethodservice.ExtractEditText> {
     ctx ->
@@ -98,6 +71,60 @@ public inline fun ViewManager.viewStub(inlineOptions(InlineOption.ONLY_LOCAL_RET
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.webView(): android.webkit.WebView = webView({})
+public inline fun ViewManager.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.webkit.WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+    ctx ->
+    val view = android.webkit.WebView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.webView(): android.webkit.WebView = webView({})
+public inline fun Context.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.webkit.WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+    ctx ->
+    val view = android.webkit.WebView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.webView(): android.webkit.WebView = webView({})
+public inline fun Activity.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.webkit.WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+    ctx ->
+    val view = android.webkit.WebView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
+public inline fun ViewManager.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
+    ctx ->
+    val view = android.widget.AbsoluteLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
+public inline fun Context.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
+    ctx ->
+    val view = android.widget.AbsoluteLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
+public inline fun Activity.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
+    ctx ->
+    val view = android.widget.AbsoluteLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.adapterViewFlipper(): android.widget.AdapterViewFlipper = adapterViewFlipper({})
 public inline fun ViewManager.adapterViewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.AdapterViewFlipper.() -> Unit): android.widget.AdapterViewFlipper = addView<android.widget.AdapterViewFlipper> {
     ctx ->
@@ -152,33 +179,6 @@ public inline fun ViewManager.button(inlineOptions(InlineOption.ONLY_LOCAL_RETUR
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.calendarView(): android.widget.CalendarView = calendarView({})
-public inline fun ViewManager.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
-    ctx ->
-    val view = android.widget.CalendarView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.calendarView(): android.widget.CalendarView = calendarView({})
-public inline fun Context.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
-    ctx ->
-    val view = android.widget.CalendarView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.calendarView(): android.widget.CalendarView = calendarView({})
-public inline fun Activity.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
-    ctx ->
-    val view = android.widget.CalendarView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.checkBox(): android.widget.CheckBox = checkBox({})
 public inline fun ViewManager.checkBox(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.CheckBox.() -> Unit): android.widget.CheckBox = addView<android.widget.CheckBox> {
     ctx ->
@@ -201,60 +201,6 @@ public inline fun ViewManager.chronometer(): android.widget.Chronometer = chrono
 public inline fun ViewManager.chronometer(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.Chronometer.() -> Unit): android.widget.Chronometer = addView<android.widget.Chronometer> {
     ctx ->
     val view = android.widget.Chronometer(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.datePicker(): android.widget.DatePicker = datePicker({})
-public inline fun ViewManager.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
-    ctx ->
-    val view = android.widget.DatePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.datePicker(): android.widget.DatePicker = datePicker({})
-public inline fun Context.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
-    ctx ->
-    val view = android.widget.DatePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.datePicker(): android.widget.DatePicker = datePicker({})
-public inline fun Activity.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
-    ctx ->
-    val view = android.widget.DatePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
-public inline fun ViewManager.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
-    ctx ->
-    val view = android.widget.DialerFilter(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
-public inline fun Context.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
-    ctx ->
-    val view = android.widget.DialerFilter(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
-public inline fun Activity.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
-    ctx ->
-    val view = android.widget.DialerFilter(ctx)
     view.init()
     view
 }
@@ -305,37 +251,64 @@ public inline fun Activity.expandableListView(inlineOptions(InlineOption.ONLY_LO
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.gallery(): android.widget.Gallery = gallery({})
+public inline fun ViewManager.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
+    ctx ->
+    val view = android.widget.Gallery(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.gallery(): android.widget.Gallery = gallery({})
+public inline fun Context.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
+    ctx ->
+    val view = android.widget.Gallery(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.gallery(): android.widget.Gallery = gallery({})
+public inline fun Activity.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
+    ctx ->
+    val view = android.widget.Gallery(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.gridView(): android.widget.GridView = gridView({})
+public inline fun ViewManager.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
+    ctx ->
+    val view = android.widget.GridView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.gridView(): android.widget.GridView = gridView({})
+public inline fun Context.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
+    ctx ->
+    val view = android.widget.GridView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.gridView(): android.widget.GridView = gridView({})
+public inline fun Activity.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
+    ctx ->
+    val view = android.widget.GridView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.imageButton(): android.widget.ImageButton = imageButton({})
 public inline fun ViewManager.imageButton(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ImageButton.() -> Unit): android.widget.ImageButton = addView<android.widget.ImageButton> {
     ctx ->
     val view = android.widget.ImageButton(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
-public inline fun ViewManager.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
-    ctx ->
-    val view = android.widget.ImageSwitcher(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
-public inline fun Context.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
-    ctx ->
-    val view = android.widget.ImageSwitcher(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
-public inline fun Activity.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
-    ctx ->
-    val view = android.widget.ImageSwitcher(ctx)
     view.init()
     view
 }
@@ -386,33 +359,6 @@ public inline fun ViewManager.multiAutoCompleteTextView(inlineOptions(InlineOpti
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.numberPicker(): android.widget.NumberPicker = numberPicker({})
-public inline fun ViewManager.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
-    ctx ->
-    val view = android.widget.NumberPicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.numberPicker(): android.widget.NumberPicker = numberPicker({})
-public inline fun Context.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
-    ctx ->
-    val view = android.widget.NumberPicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.numberPicker(): android.widget.NumberPicker = numberPicker({})
-public inline fun Activity.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
-    ctx ->
-    val view = android.widget.NumberPicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.progressBar(): android.widget.ProgressBar = progressBar({})
 public inline fun ViewManager.progressBar(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ProgressBar.() -> Unit): android.widget.ProgressBar = addView<android.widget.ProgressBar> {
     ctx ->
@@ -444,33 +390,6 @@ public inline fun ViewManager.ratingBar(): android.widget.RatingBar = ratingBar(
 public inline fun ViewManager.ratingBar(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.RatingBar.() -> Unit): android.widget.RatingBar = addView<android.widget.RatingBar> {
     ctx ->
     val view = android.widget.RatingBar(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.searchView(): android.widget.SearchView = searchView({})
-public inline fun ViewManager.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
-    ctx ->
-    val view = android.widget.SearchView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.searchView(): android.widget.SearchView = searchView({})
-public inline fun Context.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
-    ctx ->
-    val view = android.widget.SearchView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.searchView(): android.widget.SearchView = searchView({})
-public inline fun Activity.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
-    ctx ->
-    val view = android.widget.SearchView(ctx)
     view.init()
     view
 }
@@ -584,91 +503,10 @@ public inline fun ViewManager.switch(inlineOptions(InlineOption.ONLY_LOCAL_RETUR
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.tabHost(): android.widget.TabHost = tabHost({})
-public inline fun ViewManager.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
-    ctx ->
-    val view = android.widget.TabHost(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.tabHost(): android.widget.TabHost = tabHost({})
-public inline fun Context.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
-    ctx ->
-    val view = android.widget.TabHost(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.tabHost(): android.widget.TabHost = tabHost({})
-public inline fun Activity.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
-    ctx ->
-    val view = android.widget.TabHost(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.tabWidget(): android.widget.TabWidget = tabWidget({})
-public inline fun ViewManager.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
-    ctx ->
-    val view = android.widget.TabWidget(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.tabWidget(): android.widget.TabWidget = tabWidget({})
-public inline fun Context.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
-    ctx ->
-    val view = android.widget.TabWidget(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.tabWidget(): android.widget.TabWidget = tabWidget({})
-public inline fun Activity.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
-    ctx ->
-    val view = android.widget.TabWidget(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.textView(): android.widget.TextView = textView({})
 public inline fun ViewManager.textView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TextView.() -> Unit): android.widget.TextView = addView<android.widget.TextView> {
     ctx ->
     val view = android.widget.TextView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.timePicker(): android.widget.TimePicker = timePicker({})
-public inline fun ViewManager.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
-    ctx ->
-    val view = android.widget.TimePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.timePicker(): android.widget.TimePicker = timePicker({})
-public inline fun Context.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
-    ctx ->
-    val view = android.widget.TimePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.timePicker(): android.widget.TimePicker = timePicker({})
-public inline fun Activity.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
-    ctx ->
-    val view = android.widget.TimePicker(ctx)
     view.init()
     view
 }
@@ -683,33 +521,6 @@ public inline fun ViewManager.toggleButton(inlineOptions(InlineOption.ONLY_LOCAL
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
-public inline fun ViewManager.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
-    ctx ->
-    val view = android.widget.TwoLineListItem(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
-public inline fun Context.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
-    ctx ->
-    val view = android.widget.TwoLineListItem(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
-public inline fun Activity.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
-    ctx ->
-    val view = android.widget.TwoLineListItem(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.videoView(): android.widget.VideoView = videoView({})
 public inline fun ViewManager.videoView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.VideoView.() -> Unit): android.widget.VideoView = addView<android.widget.VideoView> {
     ctx ->
@@ -719,64 +530,10 @@ public inline fun ViewManager.videoView(inlineOptions(InlineOption.ONLY_LOCAL_RE
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
-public inline fun ViewManager.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
-    ctx ->
-    val view = android.widget.ViewFlipper(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
-public inline fun Context.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
-    ctx ->
-    val view = android.widget.ViewFlipper(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
-public inline fun Activity.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
-    ctx ->
-    val view = android.widget.ViewFlipper(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.zoomButton(): android.widget.ZoomButton = zoomButton({})
 public inline fun ViewManager.zoomButton(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ZoomButton.() -> Unit): android.widget.ZoomButton = addView<android.widget.ZoomButton> {
     ctx ->
     val view = android.widget.ZoomButton(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.zoomControls(): android.widget.ZoomControls = zoomControls({})
-public inline fun ViewManager.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
-    ctx ->
-    val view = android.widget.ZoomControls(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.zoomControls(): android.widget.ZoomControls = zoomControls({})
-public inline fun Context.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
-    ctx ->
-    val view = android.widget.ZoomControls(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.zoomControls(): android.widget.ZoomControls = zoomControls({})
-public inline fun Activity.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
-    ctx ->
-    val view = android.widget.ZoomControls(ctx)
     view.init()
     view
 }
@@ -809,55 +566,109 @@ public inline fun Activity.appWidgetHostView(inlineOptions(InlineOption.ONLY_LOC
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.webView(): android.webkit.WebView = webView({})
-public inline fun ViewManager.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+public inline fun ViewManager.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
+public inline fun ViewManager.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
     ctx ->
-    val view = _WebView(ctx)
+    val view = _GestureOverlayView(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun Context.webView(): android.webkit.WebView = webView({})
-public inline fun Context.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+public inline fun Context.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
+public inline fun Context.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
     ctx ->
-    val view = _WebView(ctx)
+    val view = _GestureOverlayView(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.webView(): android.webkit.WebView = webView({})
-public inline fun Activity.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+public inline fun Activity.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
+public inline fun Activity.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
     ctx ->
-    val view = _WebView(ctx)
+    val view = _GestureOverlayView(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
-public inline fun ViewManager.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
+public inline fun ViewManager.calendarView(): android.widget.CalendarView = calendarView({})
+public inline fun ViewManager.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
     ctx ->
-    val view = _AbsoluteLayout(ctx)
+    val view = _CalendarView(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun Context.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
-public inline fun Context.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
+public inline fun Context.calendarView(): android.widget.CalendarView = calendarView({})
+public inline fun Context.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
     ctx ->
-    val view = _AbsoluteLayout(ctx)
+    val view = _CalendarView(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
-public inline fun Activity.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
+public inline fun Activity.calendarView(): android.widget.CalendarView = calendarView({})
+public inline fun Activity.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
     ctx ->
-    val view = _AbsoluteLayout(ctx)
+    val view = _CalendarView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.datePicker(): android.widget.DatePicker = datePicker({})
+public inline fun ViewManager.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
+    ctx ->
+    val view = _DatePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.datePicker(): android.widget.DatePicker = datePicker({})
+public inline fun Context.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
+    ctx ->
+    val view = _DatePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.datePicker(): android.widget.DatePicker = datePicker({})
+public inline fun Activity.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
+    ctx ->
+    val view = _DatePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
+public inline fun ViewManager.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
+    ctx ->
+    val view = _DialerFilter(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
+public inline fun Context.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
+    ctx ->
+    val view = _DialerFilter(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
+public inline fun Activity.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
+    ctx ->
+    val view = _DialerFilter(ctx)
     view.init()
     view
 }
@@ -890,33 +701,6 @@ public inline fun Activity.frameLayout(inlineOptions(InlineOption.ONLY_LOCAL_RET
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.gallery(): android.widget.Gallery = gallery({})
-public inline fun ViewManager.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
-    ctx ->
-    val view = _Gallery(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.gallery(): android.widget.Gallery = gallery({})
-public inline fun Context.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
-    ctx ->
-    val view = _Gallery(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.gallery(): android.widget.Gallery = gallery({})
-public inline fun Activity.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
-    ctx ->
-    val view = _Gallery(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.gridLayout(): android.widget.GridLayout = gridLayout({})
 public inline fun ViewManager.gridLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GridLayout.() -> Unit): android.widget.GridLayout = addView<android.widget.GridLayout> {
     ctx ->
@@ -939,33 +723,6 @@ public inline fun Activity.gridLayout(): android.widget.GridLayout = gridLayout(
 public inline fun Activity.gridLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GridLayout.() -> Unit): android.widget.GridLayout = addView<android.widget.GridLayout> {
     ctx ->
     val view = _GridLayout(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.gridView(): android.widget.GridView = gridView({})
-public inline fun ViewManager.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
-    ctx ->
-    val view = _GridView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.gridView(): android.widget.GridView = gridView({})
-public inline fun Context.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
-    ctx ->
-    val view = _GridView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.gridView(): android.widget.GridView = gridView({})
-public inline fun Activity.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
-    ctx ->
-    val view = _GridView(ctx)
     view.init()
     view
 }
@@ -998,6 +755,33 @@ public inline fun Activity.horizontalScrollView(inlineOptions(InlineOption.ONLY_
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
+public inline fun ViewManager.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
+    ctx ->
+    val view = _ImageSwitcher(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
+public inline fun Context.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
+    ctx ->
+    val view = _ImageSwitcher(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
+public inline fun Activity.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
+    ctx ->
+    val view = _ImageSwitcher(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.linearLayout(): android.widget.LinearLayout = linearLayout({})
 public inline fun ViewManager.linearLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _LinearLayout.() -> Unit): android.widget.LinearLayout = addView<android.widget.LinearLayout> {
     ctx ->
@@ -1020,6 +804,33 @@ public inline fun Activity.linearLayout(): android.widget.LinearLayout = linearL
 public inline fun Activity.linearLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _LinearLayout.() -> Unit): android.widget.LinearLayout = addView<android.widget.LinearLayout> {
     ctx ->
     val view = _LinearLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.numberPicker(): android.widget.NumberPicker = numberPicker({})
+public inline fun ViewManager.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
+    ctx ->
+    val view = _NumberPicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.numberPicker(): android.widget.NumberPicker = numberPicker({})
+public inline fun Context.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
+    ctx ->
+    val view = _NumberPicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.numberPicker(): android.widget.NumberPicker = numberPicker({})
+public inline fun Activity.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
+    ctx ->
+    val view = _NumberPicker(ctx)
     view.init()
     view
 }
@@ -1106,6 +917,87 @@ public inline fun Activity.scrollView(inlineOptions(InlineOption.ONLY_LOCAL_RETU
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.searchView(): android.widget.SearchView = searchView({})
+public inline fun ViewManager.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
+    ctx ->
+    val view = _SearchView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.searchView(): android.widget.SearchView = searchView({})
+public inline fun Context.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
+    ctx ->
+    val view = _SearchView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.searchView(): android.widget.SearchView = searchView({})
+public inline fun Activity.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
+    ctx ->
+    val view = _SearchView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.tabHost(): android.widget.TabHost = tabHost({})
+public inline fun ViewManager.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
+    ctx ->
+    val view = _TabHost(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.tabHost(): android.widget.TabHost = tabHost({})
+public inline fun Context.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
+    ctx ->
+    val view = _TabHost(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.tabHost(): android.widget.TabHost = tabHost({})
+public inline fun Activity.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
+    ctx ->
+    val view = _TabHost(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.tabWidget(): android.widget.TabWidget = tabWidget({})
+public inline fun ViewManager.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
+    ctx ->
+    val view = _TabWidget(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.tabWidget(): android.widget.TabWidget = tabWidget({})
+public inline fun Context.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
+    ctx ->
+    val view = _TabWidget(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.tabWidget(): android.widget.TabWidget = tabWidget({})
+public inline fun Activity.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
+    ctx ->
+    val view = _TabWidget(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.tableLayout(): android.widget.TableLayout = tableLayout({})
 public inline fun ViewManager.tableLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TableLayout.() -> Unit): android.widget.TableLayout = addView<android.widget.TableLayout> {
     ctx ->
@@ -1187,6 +1079,60 @@ public inline fun Activity.textSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RE
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.timePicker(): android.widget.TimePicker = timePicker({})
+public inline fun ViewManager.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
+    ctx ->
+    val view = _TimePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.timePicker(): android.widget.TimePicker = timePicker({})
+public inline fun Context.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
+    ctx ->
+    val view = _TimePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.timePicker(): android.widget.TimePicker = timePicker({})
+public inline fun Activity.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
+    ctx ->
+    val view = _TimePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
+public inline fun ViewManager.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
+    ctx ->
+    val view = _TwoLineListItem(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
+public inline fun Context.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
+    ctx ->
+    val view = _TwoLineListItem(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
+public inline fun Activity.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
+    ctx ->
+    val view = _TwoLineListItem(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.viewAnimator(): android.widget.ViewAnimator = viewAnimator({})
 public inline fun ViewManager.viewAnimator(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewAnimator.() -> Unit): android.widget.ViewAnimator = addView<android.widget.ViewAnimator> {
     ctx ->
@@ -1214,6 +1160,33 @@ public inline fun Activity.viewAnimator(inlineOptions(InlineOption.ONLY_LOCAL_RE
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
+public inline fun ViewManager.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
+    ctx ->
+    val view = _ViewFlipper(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
+public inline fun Context.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
+    ctx ->
+    val view = _ViewFlipper(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
+public inline fun Activity.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
+    ctx ->
+    val view = _ViewFlipper(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.viewSwitcher(): android.widget.ViewSwitcher = viewSwitcher({})
 public inline fun ViewManager.viewSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewSwitcher.() -> Unit): android.widget.ViewSwitcher = addView<android.widget.ViewSwitcher> {
     ctx ->
@@ -1236,6 +1209,33 @@ public inline fun Activity.viewSwitcher(): android.widget.ViewSwitcher = viewSwi
 public inline fun Activity.viewSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewSwitcher.() -> Unit): android.widget.ViewSwitcher = addView<android.widget.ViewSwitcher> {
     ctx ->
     val view = _ViewSwitcher(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.zoomControls(): android.widget.ZoomControls = zoomControls({})
+public inline fun ViewManager.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
+    ctx ->
+    val view = _ZoomControls(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.zoomControls(): android.widget.ZoomControls = zoomControls({})
+public inline fun Context.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
+    ctx ->
+    val view = _ZoomControls(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.zoomControls(): android.widget.ZoomControls = zoomControls({})
+public inline fun Activity.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
+    ctx ->
+    val view = _ZoomControls(ctx)
     view.init()
     view
 }

--- a/dsl/testData/functional/15s/LayoutsTest.kt
+++ b/dsl/testData/functional/15s/LayoutsTest.kt
@@ -36,6 +36,44 @@ public open class _AppWidgetHostView(ctx: Context): android.appwidget.AppWidgetH
 
 }
 
+public open class _GestureOverlayView(ctx: Context): android.gesture.GestureOverlayView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.gestureOverlayViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.gestureOverlayViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.gestureOverlayViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.gestureOverlayViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.gestureOverlayViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
 public open class _FragmentTabHost(ctx: Context): android.support.v4.app.FragmentTabHost(ctx) {
     public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, fragmentTabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
         val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
@@ -74,107 +112,38 @@ public open class _FragmentTabHost(ctx: Context): android.support.v4.app.Fragmen
 
 }
 
-public open class _ViewPager(ctx: Context): android.support.v4.view.ViewPager(ctx) {
-    public fun <T: View> T.layoutParams( viewPagerInit: android.support.v4.view.ViewPager.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.view.ViewPager.LayoutParams()
-        layoutParams.viewPagerInit()
+public open class _NestedScrollView(ctx: Context): android.support.v4.widget.NestedScrollView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, nestedScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.nestedScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(context: android.content.Context?, attrs: android.util.AttributeSet?, viewPagerInit: android.support.v4.view.ViewPager.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.view.ViewPager.LayoutParams(context!!, attrs!!)
-        layoutParams.viewPagerInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, nestedScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.nestedScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-}
-
-public open class _DrawerLayout(ctx: Context): android.support.v4.widget.DrawerLayout(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, drawerLayoutInit: android.support.v4.widget.DrawerLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.DrawerLayout.LayoutParams(c!!, attrs!!)
-        layoutParams.drawerLayoutInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, nestedScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.nestedScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, drawerLayoutInit: android.support.v4.widget.DrawerLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.DrawerLayout.LayoutParams(width, height)
-        layoutParams.drawerLayoutInit()
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, nestedScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.nestedScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, drawerLayoutInit: android.support.v4.widget.DrawerLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.DrawerLayout.LayoutParams(width, height, gravity)
-        layoutParams.drawerLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(source: android.support.v4.widget.DrawerLayout.LayoutParams?, drawerLayoutInit: android.support.v4.widget.DrawerLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.DrawerLayout.LayoutParams(source!!)
-        layoutParams.drawerLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, drawerLayoutInit: android.support.v4.widget.DrawerLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.DrawerLayout.LayoutParams(source!!)
-        layoutParams.drawerLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, drawerLayoutInit: android.support.v4.widget.DrawerLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.DrawerLayout.LayoutParams(source!!)
-        layoutParams.drawerLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-}
-
-public open class _SlidingPaneLayout(ctx: Context): android.support.v4.widget.SlidingPaneLayout(ctx) {
-    public fun <T: View> T.layoutParams( slidingPaneLayoutInit: android.support.v4.widget.SlidingPaneLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.SlidingPaneLayout.LayoutParams()
-        layoutParams.slidingPaneLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, slidingPaneLayoutInit: android.support.v4.widget.SlidingPaneLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.SlidingPaneLayout.LayoutParams(width, height)
-        layoutParams.slidingPaneLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, slidingPaneLayoutInit: android.support.v4.widget.SlidingPaneLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.SlidingPaneLayout.LayoutParams(source!!)
-        layoutParams.slidingPaneLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, slidingPaneLayoutInit: android.support.v4.widget.SlidingPaneLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.SlidingPaneLayout.LayoutParams(source!!)
-        layoutParams.slidingPaneLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(source: android.support.v4.widget.SlidingPaneLayout.LayoutParams?, slidingPaneLayoutInit: android.support.v4.widget.SlidingPaneLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.SlidingPaneLayout.LayoutParams(source!!)
-        layoutParams.slidingPaneLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, slidingPaneLayoutInit: android.support.v4.widget.SlidingPaneLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.SlidingPaneLayout.LayoutParams(c!!, attrs!!)
-        layoutParams.slidingPaneLayoutInit()
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, nestedScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.nestedScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -257,6 +226,51 @@ public open class _LinearLayoutCompatSupport(ctx: Context): android.support.v7.w
 
 }
 
+public open class _SearchViewSupport(ctx: Context): android.support.v7.widget.SearchView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, searchViewInit: android.support.v7.widget.LinearLayoutCompat.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.support.v7.widget.LinearLayoutCompat.LayoutParams(c!!, attrs!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, searchViewInit: android.support.v7.widget.LinearLayoutCompat.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.support.v7.widget.LinearLayoutCompat.LayoutParams(width, height)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, weight: Float, searchViewInit: android.support.v7.widget.LinearLayoutCompat.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.support.v7.widget.LinearLayoutCompat.LayoutParams(width, height, weight)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(p: android.view.ViewGroup.LayoutParams?, searchViewInit: android.support.v7.widget.LinearLayoutCompat.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.support.v7.widget.LinearLayoutCompat.LayoutParams(p!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, searchViewInit: android.support.v7.widget.LinearLayoutCompat.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.support.v7.widget.LinearLayoutCompat.LayoutParams(source!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.support.v7.widget.LinearLayoutCompat.LayoutParams?, searchViewInit: android.support.v7.widget.LinearLayoutCompat.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.support.v7.widget.LinearLayoutCompat.LayoutParams(source!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
 public open class _ToolbarSupport(ctx: Context): android.support.v7.widget.Toolbar(ctx) {
     public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, toolbarInit: android.support.v7.widget.Toolbar.LayoutParams.() -> Unit = defaultInit): T {
         val layoutParams = android.support.v7.widget.Toolbar.LayoutParams(c!!, attrs!!)
@@ -316,48 +330,107 @@ public open class _ToolbarSupport(ctx: Context): android.support.v7.widget.Toolb
 
 }
 
-public open class _WebView(ctx: Context): android.webkit.WebView(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, webViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
-        layoutParams.webViewInit()
+public open class _CalendarView(ctx: Context): android.widget.CalendarView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.calendarViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, webViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
-        layoutParams.webViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.calendarViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, webViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
-        layoutParams.webViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.calendarViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.calendarViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.calendarViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
 }
 
-public open class _AbsoluteLayout(ctx: Context): android.widget.AbsoluteLayout(ctx) {
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, x: Int, y: Int, absoluteLayoutInit: android.widget.AbsoluteLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.AbsoluteLayout.LayoutParams(width, height, x, y)
-        layoutParams.absoluteLayoutInit()
+public open class _DatePicker(ctx: Context): android.widget.DatePicker(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.datePickerInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, absoluteLayoutInit: android.widget.AbsoluteLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.AbsoluteLayout.LayoutParams(c!!, attrs!!)
-        layoutParams.absoluteLayoutInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.datePickerInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, absoluteLayoutInit: android.widget.AbsoluteLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.AbsoluteLayout.LayoutParams(source!!)
-        layoutParams.absoluteLayoutInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _DialerFilter(ctx: Context): android.widget.DialerFilter(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, dialerFilterInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.dialerFilterInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, dialerFilterInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(width, height)
+        layoutParams.dialerFilterInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, dialerFilterInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.dialerFilterInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, dialerFilterInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.dialerFilterInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -396,30 +469,6 @@ public open class _FrameLayout(ctx: Context): android.widget.FrameLayout(ctx) {
     public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, frameLayoutInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
         val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
         layoutParams.frameLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-}
-
-public open class _Gallery(ctx: Context): android.widget.Gallery(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, galleryInit: android.widget.Gallery.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.Gallery.LayoutParams(c!!, attrs!!)
-        layoutParams.galleryInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, galleryInit: android.widget.Gallery.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.Gallery.LayoutParams(width, height)
-        layoutParams.galleryInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, galleryInit: android.widget.Gallery.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.Gallery.LayoutParams(source!!)
-        layoutParams.galleryInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -471,48 +520,76 @@ public open class _GridLayout(ctx: Context): android.widget.GridLayout(ctx) {
 
 }
 
-public open class _GridView(ctx: Context): android.widget.GridView(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, gridViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
-        layoutParams.gridViewInit()
+public open class _HorizontalScrollView(ctx: Context): android.widget.HorizontalScrollView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.horizontalScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gridViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
-        layoutParams.gridViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.horizontalScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, gridViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
-        layoutParams.gridViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.horizontalScrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.horizontalScrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.horizontalScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
 }
 
-public open class _HorizontalScrollView(ctx: Context): android.widget.HorizontalScrollView(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, horizontalScrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
-        layoutParams.horizontalScrollViewInit()
+public open class _ImageSwitcher(ctx: Context): android.widget.ImageSwitcher(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.imageSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, horizontalScrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
-        layoutParams.horizontalScrollViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.imageSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, horizontalScrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
-        layoutParams.horizontalScrollViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.imageSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.imageSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.imageSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -551,6 +628,44 @@ public open class _LinearLayout(ctx: Context): android.widget.LinearLayout(ctx) 
     public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, linearLayoutInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
         val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
         layoutParams.linearLayoutInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _NumberPicker(ctx: Context): android.widget.NumberPicker(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.numberPickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height)
+        layoutParams.numberPickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, weight: Float, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height, weight)
+        layoutParams.numberPickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(p: android.view.ViewGroup.LayoutParams?, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(p!!)
+        layoutParams.numberPickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.numberPickerInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -627,23 +742,151 @@ public open class _RelativeLayout(ctx: Context): android.widget.RelativeLayout(c
 }
 
 public open class _ScrollView(ctx: Context): android.widget.ScrollView(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, scrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
         layoutParams.scrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, scrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
         layoutParams.scrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, scrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
         layoutParams.scrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.scrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.scrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _SearchView(ctx: Context): android.widget.SearchView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, weight: Float, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height, weight)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(p: android.view.ViewGroup.LayoutParams?, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(p!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _TabHost(ctx: Context): android.widget.TabHost(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _TabWidget(ctx: Context): android.widget.TabWidget(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.tabWidgetInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height)
+        layoutParams.tabWidgetInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, weight: Float, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height, weight)
+        layoutParams.tabWidgetInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(p: android.view.ViewGroup.LayoutParams?, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(p!!)
+        layoutParams.tabWidgetInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.tabWidgetInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -748,23 +991,106 @@ public open class _TableRow(ctx: Context): android.widget.TableRow(ctx) {
 }
 
 public open class _TextSwitcher(ctx: Context): android.widget.TextSwitcher(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, textSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
         layoutParams.textSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, textSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
         layoutParams.textSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, textSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
         layoutParams.textSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.textSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.textSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _TimePicker(ctx: Context): android.widget.TimePicker(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _TwoLineListItem(ctx: Context): android.widget.TwoLineListItem(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, twoLineListItemInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.twoLineListItemInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, twoLineListItemInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(width, height)
+        layoutParams.twoLineListItemInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, twoLineListItemInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.twoLineListItemInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, twoLineListItemInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.twoLineListItemInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -772,22 +1098,36 @@ public open class _TextSwitcher(ctx: Context): android.widget.TextSwitcher(ctx) 
 }
 
 public open class _ViewAnimator(ctx: Context): android.widget.ViewAnimator(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewAnimatorInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
         layoutParams.viewAnimatorInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewAnimatorInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
         layoutParams.viewAnimatorInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewAnimatorInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.viewAnimatorInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewAnimatorInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
         layoutParams.viewAnimatorInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
@@ -795,24 +1135,114 @@ public open class _ViewAnimator(ctx: Context): android.widget.ViewAnimator(ctx) 
 
 }
 
+public open class _ViewFlipper(ctx: Context): android.widget.ViewFlipper(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
 public open class _ViewSwitcher(ctx: Context): android.widget.ViewSwitcher(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
         layoutParams.viewSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
         layoutParams.viewSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
         layoutParams.viewSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _ZoomControls(ctx: Context): android.widget.ZoomControls(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.zoomControlsInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height)
+        layoutParams.zoomControlsInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, weight: Float, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height, weight)
+        layoutParams.zoomControlsInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(p: android.view.ViewGroup.LayoutParams?, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(p!!)
+        layoutParams.zoomControlsInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.zoomControlsInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }

--- a/dsl/testData/functional/15s/ViewTest.kt
+++ b/dsl/testData/functional/15s/ViewTest.kt
@@ -1,31 +1,4 @@
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
-public inline fun ViewManager.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.gesture.GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
-    ctx ->
-    val view = android.gesture.GestureOverlayView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
-public inline fun Context.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.gesture.GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
-    ctx ->
-    val view = android.gesture.GestureOverlayView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
-public inline fun Activity.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.gesture.GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
-    ctx ->
-    val view = android.gesture.GestureOverlayView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.extractEditText(): android.inputmethodservice.ExtractEditText = extractEditText({})
 public inline fun ViewManager.extractEditText(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.inputmethodservice.ExtractEditText.() -> Unit): android.inputmethodservice.ExtractEditText = addView<android.inputmethodservice.ExtractEditText> {
     ctx ->
@@ -116,10 +89,91 @@ public inline fun Activity.pagerTitleStrip(inlineOptions(InlineOption.ONLY_LOCAL
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.viewPager(): android.support.v4.view.ViewPager = viewPager({})
+public inline fun ViewManager.viewPager(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.view.ViewPager.() -> Unit): android.support.v4.view.ViewPager = addView<android.support.v4.view.ViewPager> {
+    ctx ->
+    val view = android.support.v4.view.ViewPager(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.viewPager(): android.support.v4.view.ViewPager = viewPager({})
+public inline fun Context.viewPager(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.view.ViewPager.() -> Unit): android.support.v4.view.ViewPager = addView<android.support.v4.view.ViewPager> {
+    ctx ->
+    val view = android.support.v4.view.ViewPager(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.viewPager(): android.support.v4.view.ViewPager = viewPager({})
+public inline fun Activity.viewPager(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.view.ViewPager.() -> Unit): android.support.v4.view.ViewPager = addView<android.support.v4.view.ViewPager> {
+    ctx ->
+    val view = android.support.v4.view.ViewPager(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.contentLoadingProgressBar(): android.support.v4.widget.ContentLoadingProgressBar = contentLoadingProgressBar({})
 public inline fun ViewManager.contentLoadingProgressBar(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.widget.ContentLoadingProgressBar.() -> Unit): android.support.v4.widget.ContentLoadingProgressBar = addView<android.support.v4.widget.ContentLoadingProgressBar> {
     ctx ->
     val view = android.support.v4.widget.ContentLoadingProgressBar(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.drawerLayout(): android.support.v4.widget.DrawerLayout = drawerLayout({})
+public inline fun ViewManager.drawerLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.widget.DrawerLayout.() -> Unit): android.support.v4.widget.DrawerLayout = addView<android.support.v4.widget.DrawerLayout> {
+    ctx ->
+    val view = android.support.v4.widget.DrawerLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.drawerLayout(): android.support.v4.widget.DrawerLayout = drawerLayout({})
+public inline fun Context.drawerLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.widget.DrawerLayout.() -> Unit): android.support.v4.widget.DrawerLayout = addView<android.support.v4.widget.DrawerLayout> {
+    ctx ->
+    val view = android.support.v4.widget.DrawerLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.drawerLayout(): android.support.v4.widget.DrawerLayout = drawerLayout({})
+public inline fun Activity.drawerLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.widget.DrawerLayout.() -> Unit): android.support.v4.widget.DrawerLayout = addView<android.support.v4.widget.DrawerLayout> {
+    ctx ->
+    val view = android.support.v4.widget.DrawerLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.slidingPaneLayout(): android.support.v4.widget.SlidingPaneLayout = slidingPaneLayout({})
+public inline fun ViewManager.slidingPaneLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.widget.SlidingPaneLayout.() -> Unit): android.support.v4.widget.SlidingPaneLayout = addView<android.support.v4.widget.SlidingPaneLayout> {
+    ctx ->
+    val view = android.support.v4.widget.SlidingPaneLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.slidingPaneLayout(): android.support.v4.widget.SlidingPaneLayout = slidingPaneLayout({})
+public inline fun Context.slidingPaneLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.widget.SlidingPaneLayout.() -> Unit): android.support.v4.widget.SlidingPaneLayout = addView<android.support.v4.widget.SlidingPaneLayout> {
+    ctx ->
+    val view = android.support.v4.widget.SlidingPaneLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.slidingPaneLayout(): android.support.v4.widget.SlidingPaneLayout = slidingPaneLayout({})
+public inline fun Activity.slidingPaneLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.widget.SlidingPaneLayout.() -> Unit): android.support.v4.widget.SlidingPaneLayout = addView<android.support.v4.widget.SlidingPaneLayout> {
+    ctx ->
+    val view = android.support.v4.widget.SlidingPaneLayout(ctx)
     view.init()
     view
 }
@@ -152,28 +206,109 @@ public inline fun Activity.swipeRefreshLayout(inlineOptions(InlineOption.ONLY_LO
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.searchViewSupport(): android.support.v7.widget.SearchView = searchViewSupport({})
-public inline fun ViewManager.searchViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.SearchView.() -> Unit): android.support.v7.widget.SearchView = addView<android.support.v7.widget.SearchView> {
+public inline fun ViewManager.appCompatAutoCompleteTextViewSupport(): android.support.v7.widget.AppCompatAutoCompleteTextView = appCompatAutoCompleteTextViewSupport({})
+public inline fun ViewManager.appCompatAutoCompleteTextViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatAutoCompleteTextView.() -> Unit): android.support.v7.widget.AppCompatAutoCompleteTextView = addView<android.support.v7.widget.AppCompatAutoCompleteTextView> {
     ctx ->
-    val view = android.support.v7.widget.SearchView(ctx)
+    val view = android.support.v7.widget.AppCompatAutoCompleteTextView(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun Context.searchViewSupport(): android.support.v7.widget.SearchView = searchViewSupport({})
-public inline fun Context.searchViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.SearchView.() -> Unit): android.support.v7.widget.SearchView = addView<android.support.v7.widget.SearchView> {
+public inline fun ViewManager.appCompatButtonSupport(): android.support.v7.widget.AppCompatButton = appCompatButtonSupport({})
+public inline fun ViewManager.appCompatButtonSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatButton.() -> Unit): android.support.v7.widget.AppCompatButton = addView<android.support.v7.widget.AppCompatButton> {
     ctx ->
-    val view = android.support.v7.widget.SearchView(ctx)
+    val view = android.support.v7.widget.AppCompatButton(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.searchViewSupport(): android.support.v7.widget.SearchView = searchViewSupport({})
-public inline fun Activity.searchViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.SearchView.() -> Unit): android.support.v7.widget.SearchView = addView<android.support.v7.widget.SearchView> {
+public inline fun ViewManager.appCompatCheckBoxSupport(): android.support.v7.widget.AppCompatCheckBox = appCompatCheckBoxSupport({})
+public inline fun ViewManager.appCompatCheckBoxSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatCheckBox.() -> Unit): android.support.v7.widget.AppCompatCheckBox = addView<android.support.v7.widget.AppCompatCheckBox> {
     ctx ->
-    val view = android.support.v7.widget.SearchView(ctx)
+    val view = android.support.v7.widget.AppCompatCheckBox(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.appCompatCheckedTextViewSupport(): android.support.v7.widget.AppCompatCheckedTextView = appCompatCheckedTextViewSupport({})
+public inline fun ViewManager.appCompatCheckedTextViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatCheckedTextView.() -> Unit): android.support.v7.widget.AppCompatCheckedTextView = addView<android.support.v7.widget.AppCompatCheckedTextView> {
+    ctx ->
+    val view = android.support.v7.widget.AppCompatCheckedTextView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.appCompatEditTextSupport(): android.support.v7.widget.AppCompatEditText = appCompatEditTextSupport({})
+public inline fun ViewManager.appCompatEditTextSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatEditText.() -> Unit): android.support.v7.widget.AppCompatEditText = addView<android.support.v7.widget.AppCompatEditText> {
+    ctx ->
+    val view = android.support.v7.widget.AppCompatEditText(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.appCompatMultiAutoCompleteTextViewSupport(): android.support.v7.widget.AppCompatMultiAutoCompleteTextView = appCompatMultiAutoCompleteTextViewSupport({})
+public inline fun ViewManager.appCompatMultiAutoCompleteTextViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatMultiAutoCompleteTextView.() -> Unit): android.support.v7.widget.AppCompatMultiAutoCompleteTextView = addView<android.support.v7.widget.AppCompatMultiAutoCompleteTextView> {
+    ctx ->
+    val view = android.support.v7.widget.AppCompatMultiAutoCompleteTextView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.appCompatRadioButtonSupport(): android.support.v7.widget.AppCompatRadioButton = appCompatRadioButtonSupport({})
+public inline fun ViewManager.appCompatRadioButtonSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatRadioButton.() -> Unit): android.support.v7.widget.AppCompatRadioButton = addView<android.support.v7.widget.AppCompatRadioButton> {
+    ctx ->
+    val view = android.support.v7.widget.AppCompatRadioButton(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.appCompatRatingBarSupport(): android.support.v7.widget.AppCompatRatingBar = appCompatRatingBarSupport({})
+public inline fun ViewManager.appCompatRatingBarSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatRatingBar.() -> Unit): android.support.v7.widget.AppCompatRatingBar = addView<android.support.v7.widget.AppCompatRatingBar> {
+    ctx ->
+    val view = android.support.v7.widget.AppCompatRatingBar(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.appCompatSpinnerSupport(): android.support.v7.widget.AppCompatSpinner = appCompatSpinnerSupport({})
+public inline fun ViewManager.appCompatSpinnerSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatSpinner.() -> Unit): android.support.v7.widget.AppCompatSpinner = addView<android.support.v7.widget.AppCompatSpinner> {
+    ctx ->
+    val view = android.support.v7.widget.AppCompatSpinner(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.appCompatSpinnerSupport(): android.support.v7.widget.AppCompatSpinner = appCompatSpinnerSupport({})
+public inline fun Context.appCompatSpinnerSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatSpinner.() -> Unit): android.support.v7.widget.AppCompatSpinner = addView<android.support.v7.widget.AppCompatSpinner> {
+    ctx ->
+    val view = android.support.v7.widget.AppCompatSpinner(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.appCompatSpinnerSupport(): android.support.v7.widget.AppCompatSpinner = appCompatSpinnerSupport({})
+public inline fun Activity.appCompatSpinnerSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatSpinner.() -> Unit): android.support.v7.widget.AppCompatSpinner = addView<android.support.v7.widget.AppCompatSpinner> {
+    ctx ->
+    val view = android.support.v7.widget.AppCompatSpinner(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.appCompatTextViewSupport(): android.support.v7.widget.AppCompatTextView = appCompatTextViewSupport({})
+public inline fun ViewManager.appCompatTextViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatTextView.() -> Unit): android.support.v7.widget.AppCompatTextView = addView<android.support.v7.widget.AppCompatTextView> {
+    ctx ->
+    val view = android.support.v7.widget.AppCompatTextView(ctx)
     view.init()
     view
 }
@@ -219,6 +354,60 @@ public inline fun ViewManager.viewStub(): android.view.ViewStub = viewStub({})
 public inline fun ViewManager.viewStub(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.view.ViewStub.() -> Unit): android.view.ViewStub = addView<android.view.ViewStub> {
     ctx ->
     val view = android.view.ViewStub(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.webView(): android.webkit.WebView = webView({})
+public inline fun ViewManager.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.webkit.WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+    ctx ->
+    val view = android.webkit.WebView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.webView(): android.webkit.WebView = webView({})
+public inline fun Context.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.webkit.WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+    ctx ->
+    val view = android.webkit.WebView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.webView(): android.webkit.WebView = webView({})
+public inline fun Activity.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.webkit.WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+    ctx ->
+    val view = android.webkit.WebView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
+public inline fun ViewManager.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
+    ctx ->
+    val view = android.widget.AbsoluteLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
+public inline fun Context.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
+    ctx ->
+    val view = android.widget.AbsoluteLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
+public inline fun Activity.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
+    ctx ->
+    val view = android.widget.AbsoluteLayout(ctx)
     view.init()
     view
 }
@@ -278,33 +467,6 @@ public inline fun ViewManager.button(inlineOptions(InlineOption.ONLY_LOCAL_RETUR
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.calendarView(): android.widget.CalendarView = calendarView({})
-public inline fun ViewManager.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
-    ctx ->
-    val view = android.widget.CalendarView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.calendarView(): android.widget.CalendarView = calendarView({})
-public inline fun Context.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
-    ctx ->
-    val view = android.widget.CalendarView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.calendarView(): android.widget.CalendarView = calendarView({})
-public inline fun Activity.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
-    ctx ->
-    val view = android.widget.CalendarView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.checkBox(): android.widget.CheckBox = checkBox({})
 public inline fun ViewManager.checkBox(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.CheckBox.() -> Unit): android.widget.CheckBox = addView<android.widget.CheckBox> {
     ctx ->
@@ -327,60 +489,6 @@ public inline fun ViewManager.chronometer(): android.widget.Chronometer = chrono
 public inline fun ViewManager.chronometer(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.Chronometer.() -> Unit): android.widget.Chronometer = addView<android.widget.Chronometer> {
     ctx ->
     val view = android.widget.Chronometer(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.datePicker(): android.widget.DatePicker = datePicker({})
-public inline fun ViewManager.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
-    ctx ->
-    val view = android.widget.DatePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.datePicker(): android.widget.DatePicker = datePicker({})
-public inline fun Context.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
-    ctx ->
-    val view = android.widget.DatePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.datePicker(): android.widget.DatePicker = datePicker({})
-public inline fun Activity.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
-    ctx ->
-    val view = android.widget.DatePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
-public inline fun ViewManager.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
-    ctx ->
-    val view = android.widget.DialerFilter(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
-public inline fun Context.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
-    ctx ->
-    val view = android.widget.DialerFilter(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
-public inline fun Activity.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
-    ctx ->
-    val view = android.widget.DialerFilter(ctx)
     view.init()
     view
 }
@@ -431,37 +539,64 @@ public inline fun Activity.expandableListView(inlineOptions(InlineOption.ONLY_LO
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.gallery(): android.widget.Gallery = gallery({})
+public inline fun ViewManager.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
+    ctx ->
+    val view = android.widget.Gallery(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.gallery(): android.widget.Gallery = gallery({})
+public inline fun Context.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
+    ctx ->
+    val view = android.widget.Gallery(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.gallery(): android.widget.Gallery = gallery({})
+public inline fun Activity.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
+    ctx ->
+    val view = android.widget.Gallery(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.gridView(): android.widget.GridView = gridView({})
+public inline fun ViewManager.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
+    ctx ->
+    val view = android.widget.GridView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.gridView(): android.widget.GridView = gridView({})
+public inline fun Context.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
+    ctx ->
+    val view = android.widget.GridView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.gridView(): android.widget.GridView = gridView({})
+public inline fun Activity.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
+    ctx ->
+    val view = android.widget.GridView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.imageButton(): android.widget.ImageButton = imageButton({})
 public inline fun ViewManager.imageButton(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ImageButton.() -> Unit): android.widget.ImageButton = addView<android.widget.ImageButton> {
     ctx ->
     val view = android.widget.ImageButton(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
-public inline fun ViewManager.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
-    ctx ->
-    val view = android.widget.ImageSwitcher(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
-public inline fun Context.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
-    ctx ->
-    val view = android.widget.ImageSwitcher(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
-public inline fun Activity.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
-    ctx ->
-    val view = android.widget.ImageSwitcher(ctx)
     view.init()
     view
 }
@@ -512,33 +647,6 @@ public inline fun ViewManager.multiAutoCompleteTextView(inlineOptions(InlineOpti
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.numberPicker(): android.widget.NumberPicker = numberPicker({})
-public inline fun ViewManager.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
-    ctx ->
-    val view = android.widget.NumberPicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.numberPicker(): android.widget.NumberPicker = numberPicker({})
-public inline fun Context.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
-    ctx ->
-    val view = android.widget.NumberPicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.numberPicker(): android.widget.NumberPicker = numberPicker({})
-public inline fun Activity.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
-    ctx ->
-    val view = android.widget.NumberPicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.progressBar(): android.widget.ProgressBar = progressBar({})
 public inline fun ViewManager.progressBar(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ProgressBar.() -> Unit): android.widget.ProgressBar = addView<android.widget.ProgressBar> {
     ctx ->
@@ -570,33 +678,6 @@ public inline fun ViewManager.ratingBar(): android.widget.RatingBar = ratingBar(
 public inline fun ViewManager.ratingBar(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.RatingBar.() -> Unit): android.widget.RatingBar = addView<android.widget.RatingBar> {
     ctx ->
     val view = android.widget.RatingBar(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.searchView(): android.widget.SearchView = searchView({})
-public inline fun ViewManager.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
-    ctx ->
-    val view = android.widget.SearchView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.searchView(): android.widget.SearchView = searchView({})
-public inline fun Context.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
-    ctx ->
-    val view = android.widget.SearchView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.searchView(): android.widget.SearchView = searchView({})
-public inline fun Activity.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
-    ctx ->
-    val view = android.widget.SearchView(ctx)
     view.init()
     view
 }
@@ -710,91 +791,10 @@ public inline fun ViewManager.switch(inlineOptions(InlineOption.ONLY_LOCAL_RETUR
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.tabHost(): android.widget.TabHost = tabHost({})
-public inline fun ViewManager.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
-    ctx ->
-    val view = android.widget.TabHost(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.tabHost(): android.widget.TabHost = tabHost({})
-public inline fun Context.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
-    ctx ->
-    val view = android.widget.TabHost(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.tabHost(): android.widget.TabHost = tabHost({})
-public inline fun Activity.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
-    ctx ->
-    val view = android.widget.TabHost(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.tabWidget(): android.widget.TabWidget = tabWidget({})
-public inline fun ViewManager.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
-    ctx ->
-    val view = android.widget.TabWidget(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.tabWidget(): android.widget.TabWidget = tabWidget({})
-public inline fun Context.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
-    ctx ->
-    val view = android.widget.TabWidget(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.tabWidget(): android.widget.TabWidget = tabWidget({})
-public inline fun Activity.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
-    ctx ->
-    val view = android.widget.TabWidget(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.textView(): android.widget.TextView = textView({})
 public inline fun ViewManager.textView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TextView.() -> Unit): android.widget.TextView = addView<android.widget.TextView> {
     ctx ->
     val view = android.widget.TextView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.timePicker(): android.widget.TimePicker = timePicker({})
-public inline fun ViewManager.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
-    ctx ->
-    val view = android.widget.TimePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.timePicker(): android.widget.TimePicker = timePicker({})
-public inline fun Context.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
-    ctx ->
-    val view = android.widget.TimePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.timePicker(): android.widget.TimePicker = timePicker({})
-public inline fun Activity.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
-    ctx ->
-    val view = android.widget.TimePicker(ctx)
     view.init()
     view
 }
@@ -809,33 +809,6 @@ public inline fun ViewManager.toggleButton(inlineOptions(InlineOption.ONLY_LOCAL
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
-public inline fun ViewManager.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
-    ctx ->
-    val view = android.widget.TwoLineListItem(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
-public inline fun Context.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
-    ctx ->
-    val view = android.widget.TwoLineListItem(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
-public inline fun Activity.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
-    ctx ->
-    val view = android.widget.TwoLineListItem(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.videoView(): android.widget.VideoView = videoView({})
 public inline fun ViewManager.videoView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.VideoView.() -> Unit): android.widget.VideoView = addView<android.widget.VideoView> {
     ctx ->
@@ -845,64 +818,10 @@ public inline fun ViewManager.videoView(inlineOptions(InlineOption.ONLY_LOCAL_RE
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
-public inline fun ViewManager.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
-    ctx ->
-    val view = android.widget.ViewFlipper(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
-public inline fun Context.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
-    ctx ->
-    val view = android.widget.ViewFlipper(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
-public inline fun Activity.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
-    ctx ->
-    val view = android.widget.ViewFlipper(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.zoomButton(): android.widget.ZoomButton = zoomButton({})
 public inline fun ViewManager.zoomButton(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ZoomButton.() -> Unit): android.widget.ZoomButton = addView<android.widget.ZoomButton> {
     ctx ->
     val view = android.widget.ZoomButton(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.zoomControls(): android.widget.ZoomControls = zoomControls({})
-public inline fun ViewManager.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
-    ctx ->
-    val view = android.widget.ZoomControls(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.zoomControls(): android.widget.ZoomControls = zoomControls({})
-public inline fun Context.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
-    ctx ->
-    val view = android.widget.ZoomControls(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.zoomControls(): android.widget.ZoomControls = zoomControls({})
-public inline fun Activity.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
-    ctx ->
-    val view = android.widget.ZoomControls(ctx)
     view.init()
     view
 }
@@ -935,6 +854,33 @@ public inline fun Activity.appWidgetHostView(inlineOptions(InlineOption.ONLY_LOC
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
+public inline fun ViewManager.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
+    ctx ->
+    val view = _GestureOverlayView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
+public inline fun Context.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
+    ctx ->
+    val view = _GestureOverlayView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
+public inline fun Activity.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
+    ctx ->
+    val view = _GestureOverlayView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.fragmentTabHost(): android.support.v4.app.FragmentTabHost = fragmentTabHost({})
 public inline fun ViewManager.fragmentTabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _FragmentTabHost.() -> Unit): android.support.v4.app.FragmentTabHost = addView<android.support.v4.app.FragmentTabHost> {
     ctx ->
@@ -962,82 +908,28 @@ public inline fun Activity.fragmentTabHost(inlineOptions(InlineOption.ONLY_LOCAL
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.viewPager(): android.support.v4.view.ViewPager = viewPager({})
-public inline fun ViewManager.viewPager(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewPager.() -> Unit): android.support.v4.view.ViewPager = addView<android.support.v4.view.ViewPager> {
+public inline fun ViewManager.nestedScrollView(): android.support.v4.widget.NestedScrollView = nestedScrollView({})
+public inline fun ViewManager.nestedScrollView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _NestedScrollView.() -> Unit): android.support.v4.widget.NestedScrollView = addView<android.support.v4.widget.NestedScrollView> {
     ctx ->
-    val view = _ViewPager(ctx)
+    val view = _NestedScrollView(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun Context.viewPager(): android.support.v4.view.ViewPager = viewPager({})
-public inline fun Context.viewPager(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewPager.() -> Unit): android.support.v4.view.ViewPager = addView<android.support.v4.view.ViewPager> {
+public inline fun Context.nestedScrollView(): android.support.v4.widget.NestedScrollView = nestedScrollView({})
+public inline fun Context.nestedScrollView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _NestedScrollView.() -> Unit): android.support.v4.widget.NestedScrollView = addView<android.support.v4.widget.NestedScrollView> {
     ctx ->
-    val view = _ViewPager(ctx)
+    val view = _NestedScrollView(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.viewPager(): android.support.v4.view.ViewPager = viewPager({})
-public inline fun Activity.viewPager(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewPager.() -> Unit): android.support.v4.view.ViewPager = addView<android.support.v4.view.ViewPager> {
+public inline fun Activity.nestedScrollView(): android.support.v4.widget.NestedScrollView = nestedScrollView({})
+public inline fun Activity.nestedScrollView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _NestedScrollView.() -> Unit): android.support.v4.widget.NestedScrollView = addView<android.support.v4.widget.NestedScrollView> {
     ctx ->
-    val view = _ViewPager(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.drawerLayout(): android.support.v4.widget.DrawerLayout = drawerLayout({})
-public inline fun ViewManager.drawerLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DrawerLayout.() -> Unit): android.support.v4.widget.DrawerLayout = addView<android.support.v4.widget.DrawerLayout> {
-    ctx ->
-    val view = _DrawerLayout(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.drawerLayout(): android.support.v4.widget.DrawerLayout = drawerLayout({})
-public inline fun Context.drawerLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DrawerLayout.() -> Unit): android.support.v4.widget.DrawerLayout = addView<android.support.v4.widget.DrawerLayout> {
-    ctx ->
-    val view = _DrawerLayout(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.drawerLayout(): android.support.v4.widget.DrawerLayout = drawerLayout({})
-public inline fun Activity.drawerLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DrawerLayout.() -> Unit): android.support.v4.widget.DrawerLayout = addView<android.support.v4.widget.DrawerLayout> {
-    ctx ->
-    val view = _DrawerLayout(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.slidingPaneLayout(): android.support.v4.widget.SlidingPaneLayout = slidingPaneLayout({})
-public inline fun ViewManager.slidingPaneLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SlidingPaneLayout.() -> Unit): android.support.v4.widget.SlidingPaneLayout = addView<android.support.v4.widget.SlidingPaneLayout> {
-    ctx ->
-    val view = _SlidingPaneLayout(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.slidingPaneLayout(): android.support.v4.widget.SlidingPaneLayout = slidingPaneLayout({})
-public inline fun Context.slidingPaneLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SlidingPaneLayout.() -> Unit): android.support.v4.widget.SlidingPaneLayout = addView<android.support.v4.widget.SlidingPaneLayout> {
-    ctx ->
-    val view = _SlidingPaneLayout(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.slidingPaneLayout(): android.support.v4.widget.SlidingPaneLayout = slidingPaneLayout({})
-public inline fun Activity.slidingPaneLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SlidingPaneLayout.() -> Unit): android.support.v4.widget.SlidingPaneLayout = addView<android.support.v4.widget.SlidingPaneLayout> {
-    ctx ->
-    val view = _SlidingPaneLayout(ctx)
+    val view = _NestedScrollView(ctx)
     view.init()
     view
 }
@@ -1097,6 +989,33 @@ public inline fun Activity.linearLayoutCompatSupport(inlineOptions(InlineOption.
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.searchViewSupport(): android.support.v7.widget.SearchView = searchViewSupport({})
+public inline fun ViewManager.searchViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SearchViewSupport.() -> Unit): android.support.v7.widget.SearchView = addView<android.support.v7.widget.SearchView> {
+    ctx ->
+    val view = _SearchViewSupport(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.searchViewSupport(): android.support.v7.widget.SearchView = searchViewSupport({})
+public inline fun Context.searchViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SearchViewSupport.() -> Unit): android.support.v7.widget.SearchView = addView<android.support.v7.widget.SearchView> {
+    ctx ->
+    val view = _SearchViewSupport(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.searchViewSupport(): android.support.v7.widget.SearchView = searchViewSupport({})
+public inline fun Activity.searchViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SearchViewSupport.() -> Unit): android.support.v7.widget.SearchView = addView<android.support.v7.widget.SearchView> {
+    ctx ->
+    val view = _SearchViewSupport(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.toolbarSupport(): android.support.v7.widget.Toolbar = toolbarSupport({})
 public inline fun ViewManager.toolbarSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ToolbarSupport.() -> Unit): android.support.v7.widget.Toolbar = addView<android.support.v7.widget.Toolbar> {
     ctx ->
@@ -1124,55 +1043,82 @@ public inline fun Activity.toolbarSupport(inlineOptions(InlineOption.ONLY_LOCAL_
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.webView(): android.webkit.WebView = webView({})
-public inline fun ViewManager.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+public inline fun ViewManager.calendarView(): android.widget.CalendarView = calendarView({})
+public inline fun ViewManager.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
     ctx ->
-    val view = _WebView(ctx)
+    val view = _CalendarView(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun Context.webView(): android.webkit.WebView = webView({})
-public inline fun Context.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+public inline fun Context.calendarView(): android.widget.CalendarView = calendarView({})
+public inline fun Context.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
     ctx ->
-    val view = _WebView(ctx)
+    val view = _CalendarView(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.webView(): android.webkit.WebView = webView({})
-public inline fun Activity.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+public inline fun Activity.calendarView(): android.widget.CalendarView = calendarView({})
+public inline fun Activity.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
     ctx ->
-    val view = _WebView(ctx)
+    val view = _CalendarView(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
-public inline fun ViewManager.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
+public inline fun ViewManager.datePicker(): android.widget.DatePicker = datePicker({})
+public inline fun ViewManager.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
     ctx ->
-    val view = _AbsoluteLayout(ctx)
+    val view = _DatePicker(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun Context.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
-public inline fun Context.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
+public inline fun Context.datePicker(): android.widget.DatePicker = datePicker({})
+public inline fun Context.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
     ctx ->
-    val view = _AbsoluteLayout(ctx)
+    val view = _DatePicker(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
-public inline fun Activity.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
+public inline fun Activity.datePicker(): android.widget.DatePicker = datePicker({})
+public inline fun Activity.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
     ctx ->
-    val view = _AbsoluteLayout(ctx)
+    val view = _DatePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
+public inline fun ViewManager.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
+    ctx ->
+    val view = _DialerFilter(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
+public inline fun Context.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
+    ctx ->
+    val view = _DialerFilter(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
+public inline fun Activity.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
+    ctx ->
+    val view = _DialerFilter(ctx)
     view.init()
     view
 }
@@ -1205,33 +1151,6 @@ public inline fun Activity.frameLayout(inlineOptions(InlineOption.ONLY_LOCAL_RET
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.gallery(): android.widget.Gallery = gallery({})
-public inline fun ViewManager.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
-    ctx ->
-    val view = _Gallery(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.gallery(): android.widget.Gallery = gallery({})
-public inline fun Context.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
-    ctx ->
-    val view = _Gallery(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.gallery(): android.widget.Gallery = gallery({})
-public inline fun Activity.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
-    ctx ->
-    val view = _Gallery(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.gridLayout(): android.widget.GridLayout = gridLayout({})
 public inline fun ViewManager.gridLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GridLayout.() -> Unit): android.widget.GridLayout = addView<android.widget.GridLayout> {
     ctx ->
@@ -1254,33 +1173,6 @@ public inline fun Activity.gridLayout(): android.widget.GridLayout = gridLayout(
 public inline fun Activity.gridLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GridLayout.() -> Unit): android.widget.GridLayout = addView<android.widget.GridLayout> {
     ctx ->
     val view = _GridLayout(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.gridView(): android.widget.GridView = gridView({})
-public inline fun ViewManager.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
-    ctx ->
-    val view = _GridView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.gridView(): android.widget.GridView = gridView({})
-public inline fun Context.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
-    ctx ->
-    val view = _GridView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.gridView(): android.widget.GridView = gridView({})
-public inline fun Activity.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
-    ctx ->
-    val view = _GridView(ctx)
     view.init()
     view
 }
@@ -1313,6 +1205,33 @@ public inline fun Activity.horizontalScrollView(inlineOptions(InlineOption.ONLY_
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
+public inline fun ViewManager.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
+    ctx ->
+    val view = _ImageSwitcher(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
+public inline fun Context.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
+    ctx ->
+    val view = _ImageSwitcher(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
+public inline fun Activity.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
+    ctx ->
+    val view = _ImageSwitcher(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.linearLayout(): android.widget.LinearLayout = linearLayout({})
 public inline fun ViewManager.linearLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _LinearLayout.() -> Unit): android.widget.LinearLayout = addView<android.widget.LinearLayout> {
     ctx ->
@@ -1335,6 +1254,33 @@ public inline fun Activity.linearLayout(): android.widget.LinearLayout = linearL
 public inline fun Activity.linearLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _LinearLayout.() -> Unit): android.widget.LinearLayout = addView<android.widget.LinearLayout> {
     ctx ->
     val view = _LinearLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.numberPicker(): android.widget.NumberPicker = numberPicker({})
+public inline fun ViewManager.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
+    ctx ->
+    val view = _NumberPicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.numberPicker(): android.widget.NumberPicker = numberPicker({})
+public inline fun Context.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
+    ctx ->
+    val view = _NumberPicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.numberPicker(): android.widget.NumberPicker = numberPicker({})
+public inline fun Activity.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
+    ctx ->
+    val view = _NumberPicker(ctx)
     view.init()
     view
 }
@@ -1421,6 +1367,87 @@ public inline fun Activity.scrollView(inlineOptions(InlineOption.ONLY_LOCAL_RETU
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.searchView(): android.widget.SearchView = searchView({})
+public inline fun ViewManager.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
+    ctx ->
+    val view = _SearchView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.searchView(): android.widget.SearchView = searchView({})
+public inline fun Context.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
+    ctx ->
+    val view = _SearchView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.searchView(): android.widget.SearchView = searchView({})
+public inline fun Activity.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
+    ctx ->
+    val view = _SearchView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.tabHost(): android.widget.TabHost = tabHost({})
+public inline fun ViewManager.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
+    ctx ->
+    val view = _TabHost(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.tabHost(): android.widget.TabHost = tabHost({})
+public inline fun Context.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
+    ctx ->
+    val view = _TabHost(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.tabHost(): android.widget.TabHost = tabHost({})
+public inline fun Activity.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
+    ctx ->
+    val view = _TabHost(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.tabWidget(): android.widget.TabWidget = tabWidget({})
+public inline fun ViewManager.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
+    ctx ->
+    val view = _TabWidget(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.tabWidget(): android.widget.TabWidget = tabWidget({})
+public inline fun Context.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
+    ctx ->
+    val view = _TabWidget(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.tabWidget(): android.widget.TabWidget = tabWidget({})
+public inline fun Activity.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
+    ctx ->
+    val view = _TabWidget(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.tableLayout(): android.widget.TableLayout = tableLayout({})
 public inline fun ViewManager.tableLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TableLayout.() -> Unit): android.widget.TableLayout = addView<android.widget.TableLayout> {
     ctx ->
@@ -1502,6 +1529,60 @@ public inline fun Activity.textSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RE
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.timePicker(): android.widget.TimePicker = timePicker({})
+public inline fun ViewManager.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
+    ctx ->
+    val view = _TimePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.timePicker(): android.widget.TimePicker = timePicker({})
+public inline fun Context.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
+    ctx ->
+    val view = _TimePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.timePicker(): android.widget.TimePicker = timePicker({})
+public inline fun Activity.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
+    ctx ->
+    val view = _TimePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
+public inline fun ViewManager.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
+    ctx ->
+    val view = _TwoLineListItem(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
+public inline fun Context.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
+    ctx ->
+    val view = _TwoLineListItem(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
+public inline fun Activity.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
+    ctx ->
+    val view = _TwoLineListItem(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.viewAnimator(): android.widget.ViewAnimator = viewAnimator({})
 public inline fun ViewManager.viewAnimator(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewAnimator.() -> Unit): android.widget.ViewAnimator = addView<android.widget.ViewAnimator> {
     ctx ->
@@ -1529,6 +1610,33 @@ public inline fun Activity.viewAnimator(inlineOptions(InlineOption.ONLY_LOCAL_RE
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
+public inline fun ViewManager.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
+    ctx ->
+    val view = _ViewFlipper(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
+public inline fun Context.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
+    ctx ->
+    val view = _ViewFlipper(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
+public inline fun Activity.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
+    ctx ->
+    val view = _ViewFlipper(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.viewSwitcher(): android.widget.ViewSwitcher = viewSwitcher({})
 public inline fun ViewManager.viewSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewSwitcher.() -> Unit): android.widget.ViewSwitcher = addView<android.widget.ViewSwitcher> {
     ctx ->
@@ -1551,6 +1659,33 @@ public inline fun Activity.viewSwitcher(): android.widget.ViewSwitcher = viewSwi
 public inline fun Activity.viewSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewSwitcher.() -> Unit): android.widget.ViewSwitcher = addView<android.widget.ViewSwitcher> {
     ctx ->
     val view = _ViewSwitcher(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.zoomControls(): android.widget.ZoomControls = zoomControls({})
+public inline fun ViewManager.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
+    ctx ->
+    val view = _ZoomControls(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.zoomControls(): android.widget.ZoomControls = zoomControls({})
+public inline fun Context.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
+    ctx ->
+    val view = _ZoomControls(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.zoomControls(): android.widget.ZoomControls = zoomControls({})
+public inline fun Activity.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
+    ctx ->
+    val view = _ZoomControls(ctx)
     view.init()
     view
 }

--- a/dsl/testData/functional/21/LayoutsTest.kt
+++ b/dsl/testData/functional/21/LayoutsTest.kt
@@ -43,48 +43,45 @@ public open class _AppWidgetHostView(ctx: Context): android.appwidget.AppWidgetH
 
 }
 
-public open class _WebView(ctx: Context): android.webkit.WebView(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, webViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
-        layoutParams.webViewInit()
+public open class _GestureOverlayView(ctx: Context): android.gesture.GestureOverlayView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.gestureOverlayViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, webViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
-        layoutParams.webViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.gestureOverlayViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, webViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
-        layoutParams.webViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.gestureOverlayViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-}
-
-public open class _AbsoluteLayout(ctx: Context): android.widget.AbsoluteLayout(ctx) {
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, x: Int, y: Int, absoluteLayoutInit: android.widget.AbsoluteLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.AbsoluteLayout.LayoutParams(width, height, x, y)
-        layoutParams.absoluteLayoutInit()
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.gestureOverlayViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, absoluteLayoutInit: android.widget.AbsoluteLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.AbsoluteLayout.LayoutParams(c!!, attrs!!)
-        layoutParams.absoluteLayoutInit()
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.gestureOverlayViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, absoluteLayoutInit: android.widget.AbsoluteLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.AbsoluteLayout.LayoutParams(source!!)
-        layoutParams.absoluteLayoutInit()
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.gestureOverlayViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -116,6 +113,134 @@ public open class _ActionMenuView(ctx: Context): android.widget.ActionMenuView(c
     public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, actionMenuViewInit: android.widget.ActionMenuView.LayoutParams.() -> Unit = defaultInit): T {
         val layoutParams = android.widget.ActionMenuView.LayoutParams(width, height)
         layoutParams.actionMenuViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _CalendarView(ctx: Context): android.widget.CalendarView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.calendarViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.calendarViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.calendarViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.calendarViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.calendarViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.calendarViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _DatePicker(ctx: Context): android.widget.DatePicker(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _DialerFilter(ctx: Context): android.widget.DialerFilter(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, dialerFilterInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.dialerFilterInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, dialerFilterInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(width, height)
+        layoutParams.dialerFilterInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, dialerFilterInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.dialerFilterInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, dialerFilterInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.dialerFilterInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.RelativeLayout.LayoutParams?, dialerFilterInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.dialerFilterInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -167,30 +292,6 @@ public open class _FrameLayout(ctx: Context): android.widget.FrameLayout(ctx) {
 
 }
 
-public open class _Gallery(ctx: Context): android.widget.Gallery(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, galleryInit: android.widget.Gallery.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.Gallery.LayoutParams(c!!, attrs!!)
-        layoutParams.galleryInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, galleryInit: android.widget.Gallery.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.Gallery.LayoutParams(width, height)
-        layoutParams.galleryInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, galleryInit: android.widget.Gallery.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.Gallery.LayoutParams(source!!)
-        layoutParams.galleryInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-}
-
 public open class _GridLayout(ctx: Context): android.widget.GridLayout(ctx) {
     public fun <T: View> T.layoutParams(rowSpec: android.widget.GridLayout.Spec?, columnSpec: android.widget.GridLayout.Spec?, gridLayoutInit: android.widget.GridLayout.LayoutParams.() -> Unit = defaultInit): T {
         val layoutParams = android.widget.GridLayout.LayoutParams(rowSpec!!, columnSpec!!)
@@ -236,48 +337,90 @@ public open class _GridLayout(ctx: Context): android.widget.GridLayout(ctx) {
 
 }
 
-public open class _GridView(ctx: Context): android.widget.GridView(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, gridViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
-        layoutParams.gridViewInit()
+public open class _HorizontalScrollView(ctx: Context): android.widget.HorizontalScrollView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.horizontalScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gridViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
-        layoutParams.gridViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.horizontalScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, gridViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
-        layoutParams.gridViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.horizontalScrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.horizontalScrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.horizontalScrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.horizontalScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
 }
 
-public open class _HorizontalScrollView(ctx: Context): android.widget.HorizontalScrollView(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, horizontalScrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
-        layoutParams.horizontalScrollViewInit()
+public open class _ImageSwitcher(ctx: Context): android.widget.ImageSwitcher(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.imageSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, horizontalScrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
-        layoutParams.horizontalScrollViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.imageSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, horizontalScrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
-        layoutParams.horizontalScrollViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.imageSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.imageSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.imageSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.imageSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -323,6 +466,51 @@ public open class _LinearLayout(ctx: Context): android.widget.LinearLayout(ctx) 
     public fun <T: View> T.layoutParams(source: android.widget.LinearLayout.LayoutParams?, linearLayoutInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
         val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
         layoutParams.linearLayoutInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _NumberPicker(ctx: Context): android.widget.NumberPicker(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.numberPickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height)
+        layoutParams.numberPickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, weight: Float, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height, weight)
+        layoutParams.numberPickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(p: android.view.ViewGroup.LayoutParams?, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(p!!)
+        layoutParams.numberPickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.numberPickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.LinearLayout.LayoutParams?, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.numberPickerInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -406,23 +594,179 @@ public open class _RelativeLayout(ctx: Context): android.widget.RelativeLayout(c
 }
 
 public open class _ScrollView(ctx: Context): android.widget.ScrollView(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, scrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
         layoutParams.scrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, scrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
         layoutParams.scrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, scrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
         layoutParams.scrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.scrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.scrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.scrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _SearchView(ctx: Context): android.widget.SearchView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, weight: Float, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height, weight)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(p: android.view.ViewGroup.LayoutParams?, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(p!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.LinearLayout.LayoutParams?, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _TabHost(ctx: Context): android.widget.TabHost(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _TabWidget(ctx: Context): android.widget.TabWidget(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.tabWidgetInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height)
+        layoutParams.tabWidgetInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, weight: Float, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height, weight)
+        layoutParams.tabWidgetInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(p: android.view.ViewGroup.LayoutParams?, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(p!!)
+        layoutParams.tabWidgetInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.tabWidgetInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.LinearLayout.LayoutParams?, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.tabWidgetInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -527,23 +871,89 @@ public open class _TableRow(ctx: Context): android.widget.TableRow(ctx) {
 }
 
 public open class _TextSwitcher(ctx: Context): android.widget.TextSwitcher(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, textSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
         layoutParams.textSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, textSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
         layoutParams.textSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, textSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
         layoutParams.textSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.textSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.textSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.textSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _TimePicker(ctx: Context): android.widget.TimePicker(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.timePickerInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -609,23 +1019,82 @@ public open class _Toolbar(ctx: Context): android.widget.Toolbar(ctx) {
 
 }
 
+public open class _TwoLineListItem(ctx: Context): android.widget.TwoLineListItem(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, twoLineListItemInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.twoLineListItemInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, twoLineListItemInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(width, height)
+        layoutParams.twoLineListItemInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, twoLineListItemInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.twoLineListItemInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, twoLineListItemInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.twoLineListItemInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.RelativeLayout.LayoutParams?, twoLineListItemInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.twoLineListItemInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
 public open class _ViewAnimator(ctx: Context): android.widget.ViewAnimator(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewAnimatorInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
         layoutParams.viewAnimatorInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewAnimatorInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
         layoutParams.viewAnimatorInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewAnimatorInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.viewAnimatorInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewAnimatorInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewAnimatorInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
         layoutParams.viewAnimatorInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
@@ -633,24 +1102,135 @@ public open class _ViewAnimator(ctx: Context): android.widget.ViewAnimator(ctx) 
 
 }
 
+public open class _ViewFlipper(ctx: Context): android.widget.ViewFlipper(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
 public open class _ViewSwitcher(ctx: Context): android.widget.ViewSwitcher(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
         layoutParams.viewSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
         layoutParams.viewSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
         layoutParams.viewSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _ZoomControls(ctx: Context): android.widget.ZoomControls(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.zoomControlsInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height)
+        layoutParams.zoomControlsInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, weight: Float, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height, weight)
+        layoutParams.zoomControlsInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(p: android.view.ViewGroup.LayoutParams?, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(p!!)
+        layoutParams.zoomControlsInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.zoomControlsInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.LinearLayout.LayoutParams?, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.zoomControlsInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }

--- a/dsl/testData/functional/21/ViewTest.kt
+++ b/dsl/testData/functional/21/ViewTest.kt
@@ -8,33 +8,6 @@ public inline fun ViewManager.mediaRouteButton(inlineOptions(InlineOption.ONLY_L
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
-public inline fun ViewManager.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.gesture.GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
-    ctx ->
-    val view = android.gesture.GestureOverlayView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
-public inline fun Context.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.gesture.GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
-    ctx ->
-    val view = android.gesture.GestureOverlayView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
-public inline fun Activity.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.gesture.GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
-    ctx ->
-    val view = android.gesture.GestureOverlayView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.extractEditText(): android.inputmethodservice.ExtractEditText = extractEditText({})
 public inline fun ViewManager.extractEditText(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.inputmethodservice.ExtractEditText.() -> Unit): android.inputmethodservice.ExtractEditText = addView<android.inputmethodservice.ExtractEditText> {
     ctx ->
@@ -116,6 +89,60 @@ public inline fun ViewManager.viewStub(inlineOptions(InlineOption.ONLY_LOCAL_RET
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.webView(): android.webkit.WebView = webView({})
+public inline fun ViewManager.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.webkit.WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+    ctx ->
+    val view = android.webkit.WebView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.webView(): android.webkit.WebView = webView({})
+public inline fun Context.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.webkit.WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+    ctx ->
+    val view = android.webkit.WebView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.webView(): android.webkit.WebView = webView({})
+public inline fun Activity.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.webkit.WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+    ctx ->
+    val view = android.webkit.WebView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
+public inline fun ViewManager.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
+    ctx ->
+    val view = android.widget.AbsoluteLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
+public inline fun Context.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
+    ctx ->
+    val view = android.widget.AbsoluteLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
+public inline fun Activity.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
+    ctx ->
+    val view = android.widget.AbsoluteLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.adapterViewFlipper(): android.widget.AdapterViewFlipper = adapterViewFlipper({})
 public inline fun ViewManager.adapterViewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.AdapterViewFlipper.() -> Unit): android.widget.AdapterViewFlipper = addView<android.widget.AdapterViewFlipper> {
     ctx ->
@@ -170,33 +197,6 @@ public inline fun ViewManager.button(inlineOptions(InlineOption.ONLY_LOCAL_RETUR
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.calendarView(): android.widget.CalendarView = calendarView({})
-public inline fun ViewManager.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
-    ctx ->
-    val view = android.widget.CalendarView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.calendarView(): android.widget.CalendarView = calendarView({})
-public inline fun Context.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
-    ctx ->
-    val view = android.widget.CalendarView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.calendarView(): android.widget.CalendarView = calendarView({})
-public inline fun Activity.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
-    ctx ->
-    val view = android.widget.CalendarView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.checkBox(): android.widget.CheckBox = checkBox({})
 public inline fun ViewManager.checkBox(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.CheckBox.() -> Unit): android.widget.CheckBox = addView<android.widget.CheckBox> {
     ctx ->
@@ -219,60 +219,6 @@ public inline fun ViewManager.chronometer(): android.widget.Chronometer = chrono
 public inline fun ViewManager.chronometer(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.Chronometer.() -> Unit): android.widget.Chronometer = addView<android.widget.Chronometer> {
     ctx ->
     val view = android.widget.Chronometer(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.datePicker(): android.widget.DatePicker = datePicker({})
-public inline fun ViewManager.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
-    ctx ->
-    val view = android.widget.DatePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.datePicker(): android.widget.DatePicker = datePicker({})
-public inline fun Context.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
-    ctx ->
-    val view = android.widget.DatePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.datePicker(): android.widget.DatePicker = datePicker({})
-public inline fun Activity.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
-    ctx ->
-    val view = android.widget.DatePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
-public inline fun ViewManager.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
-    ctx ->
-    val view = android.widget.DialerFilter(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
-public inline fun Context.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
-    ctx ->
-    val view = android.widget.DialerFilter(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
-public inline fun Activity.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
-    ctx ->
-    val view = android.widget.DialerFilter(ctx)
     view.init()
     view
 }
@@ -323,37 +269,64 @@ public inline fun Activity.expandableListView(inlineOptions(InlineOption.ONLY_LO
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.gallery(): android.widget.Gallery = gallery({})
+public inline fun ViewManager.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
+    ctx ->
+    val view = android.widget.Gallery(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.gallery(): android.widget.Gallery = gallery({})
+public inline fun Context.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
+    ctx ->
+    val view = android.widget.Gallery(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.gallery(): android.widget.Gallery = gallery({})
+public inline fun Activity.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
+    ctx ->
+    val view = android.widget.Gallery(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.gridView(): android.widget.GridView = gridView({})
+public inline fun ViewManager.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
+    ctx ->
+    val view = android.widget.GridView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.gridView(): android.widget.GridView = gridView({})
+public inline fun Context.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
+    ctx ->
+    val view = android.widget.GridView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.gridView(): android.widget.GridView = gridView({})
+public inline fun Activity.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
+    ctx ->
+    val view = android.widget.GridView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.imageButton(): android.widget.ImageButton = imageButton({})
 public inline fun ViewManager.imageButton(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ImageButton.() -> Unit): android.widget.ImageButton = addView<android.widget.ImageButton> {
     ctx ->
     val view = android.widget.ImageButton(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
-public inline fun ViewManager.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
-    ctx ->
-    val view = android.widget.ImageSwitcher(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
-public inline fun Context.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
-    ctx ->
-    val view = android.widget.ImageSwitcher(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
-public inline fun Activity.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
-    ctx ->
-    val view = android.widget.ImageSwitcher(ctx)
     view.init()
     view
 }
@@ -404,33 +377,6 @@ public inline fun ViewManager.multiAutoCompleteTextView(inlineOptions(InlineOpti
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.numberPicker(): android.widget.NumberPicker = numberPicker({})
-public inline fun ViewManager.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
-    ctx ->
-    val view = android.widget.NumberPicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.numberPicker(): android.widget.NumberPicker = numberPicker({})
-public inline fun Context.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
-    ctx ->
-    val view = android.widget.NumberPicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.numberPicker(): android.widget.NumberPicker = numberPicker({})
-public inline fun Activity.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
-    ctx ->
-    val view = android.widget.NumberPicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.progressBar(): android.widget.ProgressBar = progressBar({})
 public inline fun ViewManager.progressBar(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ProgressBar.() -> Unit): android.widget.ProgressBar = addView<android.widget.ProgressBar> {
     ctx ->
@@ -462,33 +408,6 @@ public inline fun ViewManager.ratingBar(): android.widget.RatingBar = ratingBar(
 public inline fun ViewManager.ratingBar(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.RatingBar.() -> Unit): android.widget.RatingBar = addView<android.widget.RatingBar> {
     ctx ->
     val view = android.widget.RatingBar(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.searchView(): android.widget.SearchView = searchView({})
-public inline fun ViewManager.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
-    ctx ->
-    val view = android.widget.SearchView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.searchView(): android.widget.SearchView = searchView({})
-public inline fun Context.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
-    ctx ->
-    val view = android.widget.SearchView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.searchView(): android.widget.SearchView = searchView({})
-public inline fun Activity.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
-    ctx ->
-    val view = android.widget.SearchView(ctx)
     view.init()
     view
 }
@@ -602,60 +521,6 @@ public inline fun ViewManager.switch(inlineOptions(InlineOption.ONLY_LOCAL_RETUR
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.tabHost(): android.widget.TabHost = tabHost({})
-public inline fun ViewManager.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
-    ctx ->
-    val view = android.widget.TabHost(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.tabHost(): android.widget.TabHost = tabHost({})
-public inline fun Context.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
-    ctx ->
-    val view = android.widget.TabHost(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.tabHost(): android.widget.TabHost = tabHost({})
-public inline fun Activity.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
-    ctx ->
-    val view = android.widget.TabHost(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.tabWidget(): android.widget.TabWidget = tabWidget({})
-public inline fun ViewManager.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
-    ctx ->
-    val view = android.widget.TabWidget(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.tabWidget(): android.widget.TabWidget = tabWidget({})
-public inline fun Context.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
-    ctx ->
-    val view = android.widget.TabWidget(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.tabWidget(): android.widget.TabWidget = tabWidget({})
-public inline fun Activity.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
-    ctx ->
-    val view = android.widget.TabWidget(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.textClock(): android.widget.TextClock = textClock({})
 public inline fun ViewManager.textClock(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TextClock.() -> Unit): android.widget.TextClock = addView<android.widget.TextClock> {
     ctx ->
@@ -674,64 +539,10 @@ public inline fun ViewManager.textView(inlineOptions(InlineOption.ONLY_LOCAL_RET
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.timePicker(): android.widget.TimePicker = timePicker({})
-public inline fun ViewManager.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
-    ctx ->
-    val view = android.widget.TimePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.timePicker(): android.widget.TimePicker = timePicker({})
-public inline fun Context.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
-    ctx ->
-    val view = android.widget.TimePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.timePicker(): android.widget.TimePicker = timePicker({})
-public inline fun Activity.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
-    ctx ->
-    val view = android.widget.TimePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.toggleButton(): android.widget.ToggleButton = toggleButton({})
 public inline fun ViewManager.toggleButton(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ToggleButton.() -> Unit): android.widget.ToggleButton = addView<android.widget.ToggleButton> {
     ctx ->
     val view = android.widget.ToggleButton(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
-public inline fun ViewManager.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
-    ctx ->
-    val view = android.widget.TwoLineListItem(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
-public inline fun Context.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
-    ctx ->
-    val view = android.widget.TwoLineListItem(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
-public inline fun Activity.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
-    ctx ->
-    val view = android.widget.TwoLineListItem(ctx)
     view.init()
     view
 }
@@ -746,64 +557,10 @@ public inline fun ViewManager.videoView(inlineOptions(InlineOption.ONLY_LOCAL_RE
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
-public inline fun ViewManager.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
-    ctx ->
-    val view = android.widget.ViewFlipper(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
-public inline fun Context.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
-    ctx ->
-    val view = android.widget.ViewFlipper(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
-public inline fun Activity.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
-    ctx ->
-    val view = android.widget.ViewFlipper(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.zoomButton(): android.widget.ZoomButton = zoomButton({})
 public inline fun ViewManager.zoomButton(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ZoomButton.() -> Unit): android.widget.ZoomButton = addView<android.widget.ZoomButton> {
     ctx ->
     val view = android.widget.ZoomButton(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.zoomControls(): android.widget.ZoomControls = zoomControls({})
-public inline fun ViewManager.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
-    ctx ->
-    val view = android.widget.ZoomControls(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.zoomControls(): android.widget.ZoomControls = zoomControls({})
-public inline fun Context.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
-    ctx ->
-    val view = android.widget.ZoomControls(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.zoomControls(): android.widget.ZoomControls = zoomControls({})
-public inline fun Activity.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
-    ctx ->
-    val view = android.widget.ZoomControls(ctx)
     view.init()
     view
 }
@@ -836,55 +593,28 @@ public inline fun Activity.appWidgetHostView(inlineOptions(InlineOption.ONLY_LOC
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.webView(): android.webkit.WebView = webView({})
-public inline fun ViewManager.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+public inline fun ViewManager.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
+public inline fun ViewManager.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
     ctx ->
-    val view = _WebView(ctx)
+    val view = _GestureOverlayView(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun Context.webView(): android.webkit.WebView = webView({})
-public inline fun Context.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+public inline fun Context.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
+public inline fun Context.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
     ctx ->
-    val view = _WebView(ctx)
+    val view = _GestureOverlayView(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.webView(): android.webkit.WebView = webView({})
-public inline fun Activity.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+public inline fun Activity.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
+public inline fun Activity.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
     ctx ->
-    val view = _WebView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
-public inline fun ViewManager.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
-    ctx ->
-    val view = _AbsoluteLayout(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
-public inline fun Context.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
-    ctx ->
-    val view = _AbsoluteLayout(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
-public inline fun Activity.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
-    ctx ->
-    val view = _AbsoluteLayout(ctx)
+    val view = _GestureOverlayView(ctx)
     view.init()
     view
 }
@@ -917,6 +647,87 @@ public inline fun Activity.actionMenuView(inlineOptions(InlineOption.ONLY_LOCAL_
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.calendarView(): android.widget.CalendarView = calendarView({})
+public inline fun ViewManager.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
+    ctx ->
+    val view = _CalendarView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.calendarView(): android.widget.CalendarView = calendarView({})
+public inline fun Context.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
+    ctx ->
+    val view = _CalendarView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.calendarView(): android.widget.CalendarView = calendarView({})
+public inline fun Activity.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
+    ctx ->
+    val view = _CalendarView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.datePicker(): android.widget.DatePicker = datePicker({})
+public inline fun ViewManager.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
+    ctx ->
+    val view = _DatePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.datePicker(): android.widget.DatePicker = datePicker({})
+public inline fun Context.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
+    ctx ->
+    val view = _DatePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.datePicker(): android.widget.DatePicker = datePicker({})
+public inline fun Activity.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
+    ctx ->
+    val view = _DatePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
+public inline fun ViewManager.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
+    ctx ->
+    val view = _DialerFilter(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
+public inline fun Context.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
+    ctx ->
+    val view = _DialerFilter(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
+public inline fun Activity.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
+    ctx ->
+    val view = _DialerFilter(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.frameLayout(): android.widget.FrameLayout = frameLayout({})
 public inline fun ViewManager.frameLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _FrameLayout.() -> Unit): android.widget.FrameLayout = addView<android.widget.FrameLayout> {
     ctx ->
@@ -939,33 +750,6 @@ public inline fun Activity.frameLayout(): android.widget.FrameLayout = frameLayo
 public inline fun Activity.frameLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _FrameLayout.() -> Unit): android.widget.FrameLayout = addView<android.widget.FrameLayout> {
     ctx ->
     val view = _FrameLayout(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.gallery(): android.widget.Gallery = gallery({})
-public inline fun ViewManager.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
-    ctx ->
-    val view = _Gallery(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.gallery(): android.widget.Gallery = gallery({})
-public inline fun Context.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
-    ctx ->
-    val view = _Gallery(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.gallery(): android.widget.Gallery = gallery({})
-public inline fun Activity.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
-    ctx ->
-    val view = _Gallery(ctx)
     view.init()
     view
 }
@@ -998,33 +782,6 @@ public inline fun Activity.gridLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETU
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.gridView(): android.widget.GridView = gridView({})
-public inline fun ViewManager.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
-    ctx ->
-    val view = _GridView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.gridView(): android.widget.GridView = gridView({})
-public inline fun Context.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
-    ctx ->
-    val view = _GridView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.gridView(): android.widget.GridView = gridView({})
-public inline fun Activity.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
-    ctx ->
-    val view = _GridView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.horizontalScrollView(): android.widget.HorizontalScrollView = horizontalScrollView({})
 public inline fun ViewManager.horizontalScrollView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _HorizontalScrollView.() -> Unit): android.widget.HorizontalScrollView = addView<android.widget.HorizontalScrollView> {
     ctx ->
@@ -1052,6 +809,33 @@ public inline fun Activity.horizontalScrollView(inlineOptions(InlineOption.ONLY_
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
+public inline fun ViewManager.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
+    ctx ->
+    val view = _ImageSwitcher(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
+public inline fun Context.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
+    ctx ->
+    val view = _ImageSwitcher(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
+public inline fun Activity.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
+    ctx ->
+    val view = _ImageSwitcher(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.linearLayout(): android.widget.LinearLayout = linearLayout({})
 public inline fun ViewManager.linearLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _LinearLayout.() -> Unit): android.widget.LinearLayout = addView<android.widget.LinearLayout> {
     ctx ->
@@ -1074,6 +858,33 @@ public inline fun Activity.linearLayout(): android.widget.LinearLayout = linearL
 public inline fun Activity.linearLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _LinearLayout.() -> Unit): android.widget.LinearLayout = addView<android.widget.LinearLayout> {
     ctx ->
     val view = _LinearLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.numberPicker(): android.widget.NumberPicker = numberPicker({})
+public inline fun ViewManager.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
+    ctx ->
+    val view = _NumberPicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.numberPicker(): android.widget.NumberPicker = numberPicker({})
+public inline fun Context.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
+    ctx ->
+    val view = _NumberPicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.numberPicker(): android.widget.NumberPicker = numberPicker({})
+public inline fun Activity.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
+    ctx ->
+    val view = _NumberPicker(ctx)
     view.init()
     view
 }
@@ -1160,6 +971,87 @@ public inline fun Activity.scrollView(inlineOptions(InlineOption.ONLY_LOCAL_RETU
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.searchView(): android.widget.SearchView = searchView({})
+public inline fun ViewManager.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
+    ctx ->
+    val view = _SearchView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.searchView(): android.widget.SearchView = searchView({})
+public inline fun Context.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
+    ctx ->
+    val view = _SearchView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.searchView(): android.widget.SearchView = searchView({})
+public inline fun Activity.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
+    ctx ->
+    val view = _SearchView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.tabHost(): android.widget.TabHost = tabHost({})
+public inline fun ViewManager.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
+    ctx ->
+    val view = _TabHost(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.tabHost(): android.widget.TabHost = tabHost({})
+public inline fun Context.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
+    ctx ->
+    val view = _TabHost(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.tabHost(): android.widget.TabHost = tabHost({})
+public inline fun Activity.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
+    ctx ->
+    val view = _TabHost(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.tabWidget(): android.widget.TabWidget = tabWidget({})
+public inline fun ViewManager.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
+    ctx ->
+    val view = _TabWidget(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.tabWidget(): android.widget.TabWidget = tabWidget({})
+public inline fun Context.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
+    ctx ->
+    val view = _TabWidget(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.tabWidget(): android.widget.TabWidget = tabWidget({})
+public inline fun Activity.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
+    ctx ->
+    val view = _TabWidget(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.tableLayout(): android.widget.TableLayout = tableLayout({})
 public inline fun ViewManager.tableLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TableLayout.() -> Unit): android.widget.TableLayout = addView<android.widget.TableLayout> {
     ctx ->
@@ -1241,6 +1133,33 @@ public inline fun Activity.textSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RE
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.timePicker(): android.widget.TimePicker = timePicker({})
+public inline fun ViewManager.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
+    ctx ->
+    val view = _TimePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.timePicker(): android.widget.TimePicker = timePicker({})
+public inline fun Context.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
+    ctx ->
+    val view = _TimePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.timePicker(): android.widget.TimePicker = timePicker({})
+public inline fun Activity.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
+    ctx ->
+    val view = _TimePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.toolbar(): android.widget.Toolbar = toolbar({})
 public inline fun ViewManager.toolbar(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _Toolbar.() -> Unit): android.widget.Toolbar = addView<android.widget.Toolbar> {
     ctx ->
@@ -1263,6 +1182,33 @@ public inline fun Activity.toolbar(): android.widget.Toolbar = toolbar({})
 public inline fun Activity.toolbar(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _Toolbar.() -> Unit): android.widget.Toolbar = addView<android.widget.Toolbar> {
     ctx ->
     val view = _Toolbar(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
+public inline fun ViewManager.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
+    ctx ->
+    val view = _TwoLineListItem(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
+public inline fun Context.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
+    ctx ->
+    val view = _TwoLineListItem(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
+public inline fun Activity.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
+    ctx ->
+    val view = _TwoLineListItem(ctx)
     view.init()
     view
 }
@@ -1295,6 +1241,33 @@ public inline fun Activity.viewAnimator(inlineOptions(InlineOption.ONLY_LOCAL_RE
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
+public inline fun ViewManager.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
+    ctx ->
+    val view = _ViewFlipper(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
+public inline fun Context.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
+    ctx ->
+    val view = _ViewFlipper(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
+public inline fun Activity.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
+    ctx ->
+    val view = _ViewFlipper(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.viewSwitcher(): android.widget.ViewSwitcher = viewSwitcher({})
 public inline fun ViewManager.viewSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewSwitcher.() -> Unit): android.widget.ViewSwitcher = addView<android.widget.ViewSwitcher> {
     ctx ->
@@ -1317,6 +1290,33 @@ public inline fun Activity.viewSwitcher(): android.widget.ViewSwitcher = viewSwi
 public inline fun Activity.viewSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewSwitcher.() -> Unit): android.widget.ViewSwitcher = addView<android.widget.ViewSwitcher> {
     ctx ->
     val view = _ViewSwitcher(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.zoomControls(): android.widget.ZoomControls = zoomControls({})
+public inline fun ViewManager.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
+    ctx ->
+    val view = _ZoomControls(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.zoomControls(): android.widget.ZoomControls = zoomControls({})
+public inline fun Context.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
+    ctx ->
+    val view = _ZoomControls(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.zoomControls(): android.widget.ZoomControls = zoomControls({})
+public inline fun Activity.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
+    ctx ->
+    val view = _ZoomControls(ctx)
     view.init()
     view
 }

--- a/dsl/testData/functional/21s/LayoutsTest.kt
+++ b/dsl/testData/functional/21s/LayoutsTest.kt
@@ -43,6 +43,51 @@ public open class _AppWidgetHostView(ctx: Context): android.appwidget.AppWidgetH
 
 }
 
+public open class _GestureOverlayView(ctx: Context): android.gesture.GestureOverlayView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.gestureOverlayViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.gestureOverlayViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.gestureOverlayViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.gestureOverlayViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.gestureOverlayViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, gestureOverlayViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.gestureOverlayViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
 public open class _FragmentTabHost(ctx: Context): android.support.v4.app.FragmentTabHost(ctx) {
     public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, fragmentTabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
         val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
@@ -88,107 +133,45 @@ public open class _FragmentTabHost(ctx: Context): android.support.v4.app.Fragmen
 
 }
 
-public open class _ViewPager(ctx: Context): android.support.v4.view.ViewPager(ctx) {
-    public fun <T: View> T.layoutParams( viewPagerInit: android.support.v4.view.ViewPager.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.view.ViewPager.LayoutParams()
-        layoutParams.viewPagerInit()
+public open class _NestedScrollView(ctx: Context): android.support.v4.widget.NestedScrollView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, nestedScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.nestedScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(context: android.content.Context?, attrs: android.util.AttributeSet?, viewPagerInit: android.support.v4.view.ViewPager.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.view.ViewPager.LayoutParams(context!!, attrs!!)
-        layoutParams.viewPagerInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, nestedScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.nestedScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-}
-
-public open class _DrawerLayout(ctx: Context): android.support.v4.widget.DrawerLayout(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, drawerLayoutInit: android.support.v4.widget.DrawerLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.DrawerLayout.LayoutParams(c!!, attrs!!)
-        layoutParams.drawerLayoutInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, nestedScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.nestedScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, drawerLayoutInit: android.support.v4.widget.DrawerLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.DrawerLayout.LayoutParams(width, height)
-        layoutParams.drawerLayoutInit()
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, nestedScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.nestedScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, drawerLayoutInit: android.support.v4.widget.DrawerLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.DrawerLayout.LayoutParams(width, height, gravity)
-        layoutParams.drawerLayoutInit()
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, nestedScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.nestedScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.support.v4.widget.DrawerLayout.LayoutParams?, drawerLayoutInit: android.support.v4.widget.DrawerLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.DrawerLayout.LayoutParams(source!!)
-        layoutParams.drawerLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, drawerLayoutInit: android.support.v4.widget.DrawerLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.DrawerLayout.LayoutParams(source!!)
-        layoutParams.drawerLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, drawerLayoutInit: android.support.v4.widget.DrawerLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.DrawerLayout.LayoutParams(source!!)
-        layoutParams.drawerLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-}
-
-public open class _SlidingPaneLayout(ctx: Context): android.support.v4.widget.SlidingPaneLayout(ctx) {
-    public fun <T: View> T.layoutParams( slidingPaneLayoutInit: android.support.v4.widget.SlidingPaneLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.SlidingPaneLayout.LayoutParams()
-        layoutParams.slidingPaneLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, slidingPaneLayoutInit: android.support.v4.widget.SlidingPaneLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.SlidingPaneLayout.LayoutParams(width, height)
-        layoutParams.slidingPaneLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, slidingPaneLayoutInit: android.support.v4.widget.SlidingPaneLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.SlidingPaneLayout.LayoutParams(source!!)
-        layoutParams.slidingPaneLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, slidingPaneLayoutInit: android.support.v4.widget.SlidingPaneLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.SlidingPaneLayout.LayoutParams(source!!)
-        layoutParams.slidingPaneLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(source: android.support.v4.widget.SlidingPaneLayout.LayoutParams?, slidingPaneLayoutInit: android.support.v4.widget.SlidingPaneLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.SlidingPaneLayout.LayoutParams(source!!)
-        layoutParams.slidingPaneLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, slidingPaneLayoutInit: android.support.v4.widget.SlidingPaneLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.support.v4.widget.SlidingPaneLayout.LayoutParams(c!!, attrs!!)
-        layoutParams.slidingPaneLayoutInit()
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, nestedScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.nestedScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -271,6 +254,51 @@ public open class _LinearLayoutCompatSupport(ctx: Context): android.support.v7.w
 
 }
 
+public open class _SearchViewSupport(ctx: Context): android.support.v7.widget.SearchView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, searchViewInit: android.support.v7.widget.LinearLayoutCompat.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.support.v7.widget.LinearLayoutCompat.LayoutParams(c!!, attrs!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, searchViewInit: android.support.v7.widget.LinearLayoutCompat.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.support.v7.widget.LinearLayoutCompat.LayoutParams(width, height)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, weight: Float, searchViewInit: android.support.v7.widget.LinearLayoutCompat.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.support.v7.widget.LinearLayoutCompat.LayoutParams(width, height, weight)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(p: android.view.ViewGroup.LayoutParams?, searchViewInit: android.support.v7.widget.LinearLayoutCompat.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.support.v7.widget.LinearLayoutCompat.LayoutParams(p!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, searchViewInit: android.support.v7.widget.LinearLayoutCompat.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.support.v7.widget.LinearLayoutCompat.LayoutParams(source!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.support.v7.widget.LinearLayoutCompat.LayoutParams?, searchViewInit: android.support.v7.widget.LinearLayoutCompat.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.support.v7.widget.LinearLayoutCompat.LayoutParams(source!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
 public open class _ToolbarSupport(ctx: Context): android.support.v7.widget.Toolbar(ctx) {
     public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, toolbarInit: android.support.v7.widget.Toolbar.LayoutParams.() -> Unit = defaultInit): T {
         val layoutParams = android.support.v7.widget.Toolbar.LayoutParams(c!!, attrs!!)
@@ -330,54 +358,6 @@ public open class _ToolbarSupport(ctx: Context): android.support.v7.widget.Toolb
 
 }
 
-public open class _WebView(ctx: Context): android.webkit.WebView(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, webViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
-        layoutParams.webViewInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, webViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
-        layoutParams.webViewInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, webViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
-        layoutParams.webViewInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-}
-
-public open class _AbsoluteLayout(ctx: Context): android.widget.AbsoluteLayout(ctx) {
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, x: Int, y: Int, absoluteLayoutInit: android.widget.AbsoluteLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.AbsoluteLayout.LayoutParams(width, height, x, y)
-        layoutParams.absoluteLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, absoluteLayoutInit: android.widget.AbsoluteLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.AbsoluteLayout.LayoutParams(c!!, attrs!!)
-        layoutParams.absoluteLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, absoluteLayoutInit: android.widget.AbsoluteLayout.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.AbsoluteLayout.LayoutParams(source!!)
-        layoutParams.absoluteLayoutInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-}
-
 public open class _ActionMenuView(ctx: Context): android.widget.ActionMenuView(ctx) {
     public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, actionMenuViewInit: android.widget.ActionMenuView.LayoutParams.() -> Unit = defaultInit): T {
         val layoutParams = android.widget.ActionMenuView.LayoutParams(c!!, attrs!!)
@@ -403,6 +383,134 @@ public open class _ActionMenuView(ctx: Context): android.widget.ActionMenuView(c
     public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, actionMenuViewInit: android.widget.ActionMenuView.LayoutParams.() -> Unit = defaultInit): T {
         val layoutParams = android.widget.ActionMenuView.LayoutParams(width, height)
         layoutParams.actionMenuViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _CalendarView(ctx: Context): android.widget.CalendarView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.calendarViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.calendarViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.calendarViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.calendarViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.calendarViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, calendarViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.calendarViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _DatePicker(ctx: Context): android.widget.DatePicker(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, datePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.datePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _DialerFilter(ctx: Context): android.widget.DialerFilter(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, dialerFilterInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.dialerFilterInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, dialerFilterInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(width, height)
+        layoutParams.dialerFilterInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, dialerFilterInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.dialerFilterInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, dialerFilterInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.dialerFilterInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.RelativeLayout.LayoutParams?, dialerFilterInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.dialerFilterInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -454,30 +562,6 @@ public open class _FrameLayout(ctx: Context): android.widget.FrameLayout(ctx) {
 
 }
 
-public open class _Gallery(ctx: Context): android.widget.Gallery(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, galleryInit: android.widget.Gallery.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.Gallery.LayoutParams(c!!, attrs!!)
-        layoutParams.galleryInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, galleryInit: android.widget.Gallery.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.Gallery.LayoutParams(width, height)
-        layoutParams.galleryInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, galleryInit: android.widget.Gallery.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.widget.Gallery.LayoutParams(source!!)
-        layoutParams.galleryInit()
-        this@layoutParams.setLayoutParams(layoutParams)
-        return this
-    }
-
-}
-
 public open class _GridLayout(ctx: Context): android.widget.GridLayout(ctx) {
     public fun <T: View> T.layoutParams(rowSpec: android.widget.GridLayout.Spec?, columnSpec: android.widget.GridLayout.Spec?, gridLayoutInit: android.widget.GridLayout.LayoutParams.() -> Unit = defaultInit): T {
         val layoutParams = android.widget.GridLayout.LayoutParams(rowSpec!!, columnSpec!!)
@@ -523,48 +607,90 @@ public open class _GridLayout(ctx: Context): android.widget.GridLayout(ctx) {
 
 }
 
-public open class _GridView(ctx: Context): android.widget.GridView(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, gridViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
-        layoutParams.gridViewInit()
+public open class _HorizontalScrollView(ctx: Context): android.widget.HorizontalScrollView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.horizontalScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gridViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
-        layoutParams.gridViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.horizontalScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, gridViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
-        layoutParams.gridViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.horizontalScrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.horizontalScrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.horizontalScrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, horizontalScrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.horizontalScrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
 }
 
-public open class _HorizontalScrollView(ctx: Context): android.widget.HorizontalScrollView(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, horizontalScrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
-        layoutParams.horizontalScrollViewInit()
+public open class _ImageSwitcher(ctx: Context): android.widget.ImageSwitcher(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.imageSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, horizontalScrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
-        layoutParams.horizontalScrollViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.imageSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, horizontalScrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
-        layoutParams.horizontalScrollViewInit()
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.imageSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.imageSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.imageSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, imageSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.imageSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -610,6 +736,51 @@ public open class _LinearLayout(ctx: Context): android.widget.LinearLayout(ctx) 
     public fun <T: View> T.layoutParams(source: android.widget.LinearLayout.LayoutParams?, linearLayoutInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
         val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
         layoutParams.linearLayoutInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _NumberPicker(ctx: Context): android.widget.NumberPicker(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.numberPickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height)
+        layoutParams.numberPickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, weight: Float, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height, weight)
+        layoutParams.numberPickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(p: android.view.ViewGroup.LayoutParams?, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(p!!)
+        layoutParams.numberPickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.numberPickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.LinearLayout.LayoutParams?, numberPickerInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.numberPickerInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -693,23 +864,179 @@ public open class _RelativeLayout(ctx: Context): android.widget.RelativeLayout(c
 }
 
 public open class _ScrollView(ctx: Context): android.widget.ScrollView(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, scrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
         layoutParams.scrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, scrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
         layoutParams.scrollViewInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, scrollViewInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
         layoutParams.scrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.scrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.scrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, scrollViewInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.scrollViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _SearchView(ctx: Context): android.widget.SearchView(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, weight: Float, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height, weight)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(p: android.view.ViewGroup.LayoutParams?, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(p!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.LinearLayout.LayoutParams?, searchViewInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.searchViewInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _TabHost(ctx: Context): android.widget.TabHost(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, tabHostInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.tabHostInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _TabWidget(ctx: Context): android.widget.TabWidget(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.tabWidgetInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height)
+        layoutParams.tabWidgetInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, weight: Float, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height, weight)
+        layoutParams.tabWidgetInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(p: android.view.ViewGroup.LayoutParams?, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(p!!)
+        layoutParams.tabWidgetInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.tabWidgetInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.LinearLayout.LayoutParams?, tabWidgetInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.tabWidgetInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -814,23 +1141,89 @@ public open class _TableRow(ctx: Context): android.widget.TableRow(ctx) {
 }
 
 public open class _TextSwitcher(ctx: Context): android.widget.TextSwitcher(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, textSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
         layoutParams.textSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, textSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
         layoutParams.textSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, textSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
         layoutParams.textSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.textSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.textSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, textSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.textSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _TimePicker(ctx: Context): android.widget.TimePicker(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.timePickerInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, timePickerInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.timePickerInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
@@ -896,23 +1289,82 @@ public open class _Toolbar(ctx: Context): android.widget.Toolbar(ctx) {
 
 }
 
+public open class _TwoLineListItem(ctx: Context): android.widget.TwoLineListItem(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, twoLineListItemInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.twoLineListItemInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, twoLineListItemInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(width, height)
+        layoutParams.twoLineListItemInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, twoLineListItemInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.twoLineListItemInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, twoLineListItemInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.twoLineListItemInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.RelativeLayout.LayoutParams?, twoLineListItemInit: android.widget.RelativeLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.RelativeLayout.LayoutParams(source!!)
+        layoutParams.twoLineListItemInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
 public open class _ViewAnimator(ctx: Context): android.widget.ViewAnimator(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewAnimatorInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
         layoutParams.viewAnimatorInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewAnimatorInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
         layoutParams.viewAnimatorInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewAnimatorInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.viewAnimatorInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewAnimatorInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewAnimatorInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, viewAnimatorInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
         layoutParams.viewAnimatorInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
@@ -920,24 +1372,135 @@ public open class _ViewAnimator(ctx: Context): android.widget.ViewAnimator(ctx) 
 
 }
 
+public open class _ViewFlipper(ctx: Context): android.widget.ViewFlipper(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, viewFlipperInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewFlipperInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
 public open class _ViewSwitcher(ctx: Context): android.widget.ViewSwitcher(ctx) {
-    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(c!!, attrs!!)
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(c!!, attrs!!)
         layoutParams.viewSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(width, height)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height)
         layoutParams.viewSwitcherInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }
 
-    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewSwitcherInit: android.view.ViewGroup.LayoutParams.() -> Unit = defaultInit): T {
-        val layoutParams = android.view.ViewGroup.LayoutParams(source!!)
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, gravity: Int, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(width, height, gravity)
         layoutParams.viewSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.LayoutParams?, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.FrameLayout.LayoutParams?, viewSwitcherInit: android.widget.FrameLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.FrameLayout.LayoutParams(source!!)
+        layoutParams.viewSwitcherInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+}
+
+public open class _ZoomControls(ctx: Context): android.widget.ZoomControls(ctx) {
+    public fun <T: View> T.layoutParams(c: android.content.Context?, attrs: android.util.AttributeSet?, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(c!!, attrs!!)
+        layoutParams.zoomControlsInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height)
+        layoutParams.zoomControlsInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(width: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, height: Int = android.view.ViewGroup.LayoutParams.WRAP_CONTENT, weight: Float, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(width, height, weight)
+        layoutParams.zoomControlsInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(p: android.view.ViewGroup.LayoutParams?, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(p!!)
+        layoutParams.zoomControlsInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.view.ViewGroup.MarginLayoutParams?, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.zoomControlsInit()
+        this@layoutParams.setLayoutParams(layoutParams)
+        return this
+    }
+
+    public fun <T: View> T.layoutParams(source: android.widget.LinearLayout.LayoutParams?, zoomControlsInit: android.widget.LinearLayout.LayoutParams.() -> Unit = defaultInit): T {
+        val layoutParams = android.widget.LinearLayout.LayoutParams(source!!)
+        layoutParams.zoomControlsInit()
         this@layoutParams.setLayoutParams(layoutParams)
         return this
     }

--- a/dsl/testData/functional/21s/ViewTest.kt
+++ b/dsl/testData/functional/21s/ViewTest.kt
@@ -8,33 +8,6 @@ public inline fun ViewManager.mediaRouteButton(inlineOptions(InlineOption.ONLY_L
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
-public inline fun ViewManager.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.gesture.GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
-    ctx ->
-    val view = android.gesture.GestureOverlayView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
-public inline fun Context.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.gesture.GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
-    ctx ->
-    val view = android.gesture.GestureOverlayView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
-public inline fun Activity.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.gesture.GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
-    ctx ->
-    val view = android.gesture.GestureOverlayView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.extractEditText(): android.inputmethodservice.ExtractEditText = extractEditText({})
 public inline fun ViewManager.extractEditText(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.inputmethodservice.ExtractEditText.() -> Unit): android.inputmethodservice.ExtractEditText = addView<android.inputmethodservice.ExtractEditText> {
     ctx ->
@@ -134,10 +107,91 @@ public inline fun Activity.pagerTitleStrip(inlineOptions(InlineOption.ONLY_LOCAL
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.viewPager(): android.support.v4.view.ViewPager = viewPager({})
+public inline fun ViewManager.viewPager(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.view.ViewPager.() -> Unit): android.support.v4.view.ViewPager = addView<android.support.v4.view.ViewPager> {
+    ctx ->
+    val view = android.support.v4.view.ViewPager(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.viewPager(): android.support.v4.view.ViewPager = viewPager({})
+public inline fun Context.viewPager(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.view.ViewPager.() -> Unit): android.support.v4.view.ViewPager = addView<android.support.v4.view.ViewPager> {
+    ctx ->
+    val view = android.support.v4.view.ViewPager(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.viewPager(): android.support.v4.view.ViewPager = viewPager({})
+public inline fun Activity.viewPager(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.view.ViewPager.() -> Unit): android.support.v4.view.ViewPager = addView<android.support.v4.view.ViewPager> {
+    ctx ->
+    val view = android.support.v4.view.ViewPager(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.contentLoadingProgressBar(): android.support.v4.widget.ContentLoadingProgressBar = contentLoadingProgressBar({})
 public inline fun ViewManager.contentLoadingProgressBar(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.widget.ContentLoadingProgressBar.() -> Unit): android.support.v4.widget.ContentLoadingProgressBar = addView<android.support.v4.widget.ContentLoadingProgressBar> {
     ctx ->
     val view = android.support.v4.widget.ContentLoadingProgressBar(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.drawerLayout(): android.support.v4.widget.DrawerLayout = drawerLayout({})
+public inline fun ViewManager.drawerLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.widget.DrawerLayout.() -> Unit): android.support.v4.widget.DrawerLayout = addView<android.support.v4.widget.DrawerLayout> {
+    ctx ->
+    val view = android.support.v4.widget.DrawerLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.drawerLayout(): android.support.v4.widget.DrawerLayout = drawerLayout({})
+public inline fun Context.drawerLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.widget.DrawerLayout.() -> Unit): android.support.v4.widget.DrawerLayout = addView<android.support.v4.widget.DrawerLayout> {
+    ctx ->
+    val view = android.support.v4.widget.DrawerLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.drawerLayout(): android.support.v4.widget.DrawerLayout = drawerLayout({})
+public inline fun Activity.drawerLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.widget.DrawerLayout.() -> Unit): android.support.v4.widget.DrawerLayout = addView<android.support.v4.widget.DrawerLayout> {
+    ctx ->
+    val view = android.support.v4.widget.DrawerLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.slidingPaneLayout(): android.support.v4.widget.SlidingPaneLayout = slidingPaneLayout({})
+public inline fun ViewManager.slidingPaneLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.widget.SlidingPaneLayout.() -> Unit): android.support.v4.widget.SlidingPaneLayout = addView<android.support.v4.widget.SlidingPaneLayout> {
+    ctx ->
+    val view = android.support.v4.widget.SlidingPaneLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.slidingPaneLayout(): android.support.v4.widget.SlidingPaneLayout = slidingPaneLayout({})
+public inline fun Context.slidingPaneLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.widget.SlidingPaneLayout.() -> Unit): android.support.v4.widget.SlidingPaneLayout = addView<android.support.v4.widget.SlidingPaneLayout> {
+    ctx ->
+    val view = android.support.v4.widget.SlidingPaneLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.slidingPaneLayout(): android.support.v4.widget.SlidingPaneLayout = slidingPaneLayout({})
+public inline fun Activity.slidingPaneLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v4.widget.SlidingPaneLayout.() -> Unit): android.support.v4.widget.SlidingPaneLayout = addView<android.support.v4.widget.SlidingPaneLayout> {
+    ctx ->
+    val view = android.support.v4.widget.SlidingPaneLayout(ctx)
     view.init()
     view
 }
@@ -170,28 +224,109 @@ public inline fun Activity.swipeRefreshLayout(inlineOptions(InlineOption.ONLY_LO
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.searchViewSupport(): android.support.v7.widget.SearchView = searchViewSupport({})
-public inline fun ViewManager.searchViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.SearchView.() -> Unit): android.support.v7.widget.SearchView = addView<android.support.v7.widget.SearchView> {
+public inline fun ViewManager.appCompatAutoCompleteTextViewSupport(): android.support.v7.widget.AppCompatAutoCompleteTextView = appCompatAutoCompleteTextViewSupport({})
+public inline fun ViewManager.appCompatAutoCompleteTextViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatAutoCompleteTextView.() -> Unit): android.support.v7.widget.AppCompatAutoCompleteTextView = addView<android.support.v7.widget.AppCompatAutoCompleteTextView> {
     ctx ->
-    val view = android.support.v7.widget.SearchView(ctx)
+    val view = android.support.v7.widget.AppCompatAutoCompleteTextView(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun Context.searchViewSupport(): android.support.v7.widget.SearchView = searchViewSupport({})
-public inline fun Context.searchViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.SearchView.() -> Unit): android.support.v7.widget.SearchView = addView<android.support.v7.widget.SearchView> {
+public inline fun ViewManager.appCompatButtonSupport(): android.support.v7.widget.AppCompatButton = appCompatButtonSupport({})
+public inline fun ViewManager.appCompatButtonSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatButton.() -> Unit): android.support.v7.widget.AppCompatButton = addView<android.support.v7.widget.AppCompatButton> {
     ctx ->
-    val view = android.support.v7.widget.SearchView(ctx)
+    val view = android.support.v7.widget.AppCompatButton(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.searchViewSupport(): android.support.v7.widget.SearchView = searchViewSupport({})
-public inline fun Activity.searchViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.SearchView.() -> Unit): android.support.v7.widget.SearchView = addView<android.support.v7.widget.SearchView> {
+public inline fun ViewManager.appCompatCheckBoxSupport(): android.support.v7.widget.AppCompatCheckBox = appCompatCheckBoxSupport({})
+public inline fun ViewManager.appCompatCheckBoxSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatCheckBox.() -> Unit): android.support.v7.widget.AppCompatCheckBox = addView<android.support.v7.widget.AppCompatCheckBox> {
     ctx ->
-    val view = android.support.v7.widget.SearchView(ctx)
+    val view = android.support.v7.widget.AppCompatCheckBox(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.appCompatCheckedTextViewSupport(): android.support.v7.widget.AppCompatCheckedTextView = appCompatCheckedTextViewSupport({})
+public inline fun ViewManager.appCompatCheckedTextViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatCheckedTextView.() -> Unit): android.support.v7.widget.AppCompatCheckedTextView = addView<android.support.v7.widget.AppCompatCheckedTextView> {
+    ctx ->
+    val view = android.support.v7.widget.AppCompatCheckedTextView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.appCompatEditTextSupport(): android.support.v7.widget.AppCompatEditText = appCompatEditTextSupport({})
+public inline fun ViewManager.appCompatEditTextSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatEditText.() -> Unit): android.support.v7.widget.AppCompatEditText = addView<android.support.v7.widget.AppCompatEditText> {
+    ctx ->
+    val view = android.support.v7.widget.AppCompatEditText(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.appCompatMultiAutoCompleteTextViewSupport(): android.support.v7.widget.AppCompatMultiAutoCompleteTextView = appCompatMultiAutoCompleteTextViewSupport({})
+public inline fun ViewManager.appCompatMultiAutoCompleteTextViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatMultiAutoCompleteTextView.() -> Unit): android.support.v7.widget.AppCompatMultiAutoCompleteTextView = addView<android.support.v7.widget.AppCompatMultiAutoCompleteTextView> {
+    ctx ->
+    val view = android.support.v7.widget.AppCompatMultiAutoCompleteTextView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.appCompatRadioButtonSupport(): android.support.v7.widget.AppCompatRadioButton = appCompatRadioButtonSupport({})
+public inline fun ViewManager.appCompatRadioButtonSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatRadioButton.() -> Unit): android.support.v7.widget.AppCompatRadioButton = addView<android.support.v7.widget.AppCompatRadioButton> {
+    ctx ->
+    val view = android.support.v7.widget.AppCompatRadioButton(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.appCompatRatingBarSupport(): android.support.v7.widget.AppCompatRatingBar = appCompatRatingBarSupport({})
+public inline fun ViewManager.appCompatRatingBarSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatRatingBar.() -> Unit): android.support.v7.widget.AppCompatRatingBar = addView<android.support.v7.widget.AppCompatRatingBar> {
+    ctx ->
+    val view = android.support.v7.widget.AppCompatRatingBar(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.appCompatSpinnerSupport(): android.support.v7.widget.AppCompatSpinner = appCompatSpinnerSupport({})
+public inline fun ViewManager.appCompatSpinnerSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatSpinner.() -> Unit): android.support.v7.widget.AppCompatSpinner = addView<android.support.v7.widget.AppCompatSpinner> {
+    ctx ->
+    val view = android.support.v7.widget.AppCompatSpinner(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.appCompatSpinnerSupport(): android.support.v7.widget.AppCompatSpinner = appCompatSpinnerSupport({})
+public inline fun Context.appCompatSpinnerSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatSpinner.() -> Unit): android.support.v7.widget.AppCompatSpinner = addView<android.support.v7.widget.AppCompatSpinner> {
+    ctx ->
+    val view = android.support.v7.widget.AppCompatSpinner(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.appCompatSpinnerSupport(): android.support.v7.widget.AppCompatSpinner = appCompatSpinnerSupport({})
+public inline fun Activity.appCompatSpinnerSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatSpinner.() -> Unit): android.support.v7.widget.AppCompatSpinner = addView<android.support.v7.widget.AppCompatSpinner> {
+    ctx ->
+    val view = android.support.v7.widget.AppCompatSpinner(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.appCompatTextViewSupport(): android.support.v7.widget.AppCompatTextView = appCompatTextViewSupport({})
+public inline fun ViewManager.appCompatTextViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.support.v7.widget.AppCompatTextView.() -> Unit): android.support.v7.widget.AppCompatTextView = addView<android.support.v7.widget.AppCompatTextView> {
+    ctx ->
+    val view = android.support.v7.widget.AppCompatTextView(ctx)
     view.init()
     view
 }
@@ -237,6 +372,60 @@ public inline fun ViewManager.viewStub(): android.view.ViewStub = viewStub({})
 public inline fun ViewManager.viewStub(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.view.ViewStub.() -> Unit): android.view.ViewStub = addView<android.view.ViewStub> {
     ctx ->
     val view = android.view.ViewStub(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.webView(): android.webkit.WebView = webView({})
+public inline fun ViewManager.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.webkit.WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+    ctx ->
+    val view = android.webkit.WebView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.webView(): android.webkit.WebView = webView({})
+public inline fun Context.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.webkit.WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+    ctx ->
+    val view = android.webkit.WebView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.webView(): android.webkit.WebView = webView({})
+public inline fun Activity.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.webkit.WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
+    ctx ->
+    val view = android.webkit.WebView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
+public inline fun ViewManager.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
+    ctx ->
+    val view = android.widget.AbsoluteLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
+public inline fun Context.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
+    ctx ->
+    val view = android.widget.AbsoluteLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
+public inline fun Activity.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
+    ctx ->
+    val view = android.widget.AbsoluteLayout(ctx)
     view.init()
     view
 }
@@ -296,33 +485,6 @@ public inline fun ViewManager.button(inlineOptions(InlineOption.ONLY_LOCAL_RETUR
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.calendarView(): android.widget.CalendarView = calendarView({})
-public inline fun ViewManager.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
-    ctx ->
-    val view = android.widget.CalendarView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.calendarView(): android.widget.CalendarView = calendarView({})
-public inline fun Context.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
-    ctx ->
-    val view = android.widget.CalendarView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.calendarView(): android.widget.CalendarView = calendarView({})
-public inline fun Activity.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
-    ctx ->
-    val view = android.widget.CalendarView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.checkBox(): android.widget.CheckBox = checkBox({})
 public inline fun ViewManager.checkBox(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.CheckBox.() -> Unit): android.widget.CheckBox = addView<android.widget.CheckBox> {
     ctx ->
@@ -345,60 +507,6 @@ public inline fun ViewManager.chronometer(): android.widget.Chronometer = chrono
 public inline fun ViewManager.chronometer(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.Chronometer.() -> Unit): android.widget.Chronometer = addView<android.widget.Chronometer> {
     ctx ->
     val view = android.widget.Chronometer(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.datePicker(): android.widget.DatePicker = datePicker({})
-public inline fun ViewManager.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
-    ctx ->
-    val view = android.widget.DatePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.datePicker(): android.widget.DatePicker = datePicker({})
-public inline fun Context.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
-    ctx ->
-    val view = android.widget.DatePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.datePicker(): android.widget.DatePicker = datePicker({})
-public inline fun Activity.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
-    ctx ->
-    val view = android.widget.DatePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
-public inline fun ViewManager.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
-    ctx ->
-    val view = android.widget.DialerFilter(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
-public inline fun Context.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
-    ctx ->
-    val view = android.widget.DialerFilter(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
-public inline fun Activity.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
-    ctx ->
-    val view = android.widget.DialerFilter(ctx)
     view.init()
     view
 }
@@ -449,37 +557,64 @@ public inline fun Activity.expandableListView(inlineOptions(InlineOption.ONLY_LO
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.gallery(): android.widget.Gallery = gallery({})
+public inline fun ViewManager.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
+    ctx ->
+    val view = android.widget.Gallery(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.gallery(): android.widget.Gallery = gallery({})
+public inline fun Context.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
+    ctx ->
+    val view = android.widget.Gallery(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.gallery(): android.widget.Gallery = gallery({})
+public inline fun Activity.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
+    ctx ->
+    val view = android.widget.Gallery(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.gridView(): android.widget.GridView = gridView({})
+public inline fun ViewManager.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
+    ctx ->
+    val view = android.widget.GridView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.gridView(): android.widget.GridView = gridView({})
+public inline fun Context.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
+    ctx ->
+    val view = android.widget.GridView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.gridView(): android.widget.GridView = gridView({})
+public inline fun Activity.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
+    ctx ->
+    val view = android.widget.GridView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.imageButton(): android.widget.ImageButton = imageButton({})
 public inline fun ViewManager.imageButton(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ImageButton.() -> Unit): android.widget.ImageButton = addView<android.widget.ImageButton> {
     ctx ->
     val view = android.widget.ImageButton(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
-public inline fun ViewManager.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
-    ctx ->
-    val view = android.widget.ImageSwitcher(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
-public inline fun Context.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
-    ctx ->
-    val view = android.widget.ImageSwitcher(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
-public inline fun Activity.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
-    ctx ->
-    val view = android.widget.ImageSwitcher(ctx)
     view.init()
     view
 }
@@ -530,33 +665,6 @@ public inline fun ViewManager.multiAutoCompleteTextView(inlineOptions(InlineOpti
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.numberPicker(): android.widget.NumberPicker = numberPicker({})
-public inline fun ViewManager.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
-    ctx ->
-    val view = android.widget.NumberPicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.numberPicker(): android.widget.NumberPicker = numberPicker({})
-public inline fun Context.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
-    ctx ->
-    val view = android.widget.NumberPicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.numberPicker(): android.widget.NumberPicker = numberPicker({})
-public inline fun Activity.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
-    ctx ->
-    val view = android.widget.NumberPicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.progressBar(): android.widget.ProgressBar = progressBar({})
 public inline fun ViewManager.progressBar(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ProgressBar.() -> Unit): android.widget.ProgressBar = addView<android.widget.ProgressBar> {
     ctx ->
@@ -588,33 +696,6 @@ public inline fun ViewManager.ratingBar(): android.widget.RatingBar = ratingBar(
 public inline fun ViewManager.ratingBar(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.RatingBar.() -> Unit): android.widget.RatingBar = addView<android.widget.RatingBar> {
     ctx ->
     val view = android.widget.RatingBar(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.searchView(): android.widget.SearchView = searchView({})
-public inline fun ViewManager.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
-    ctx ->
-    val view = android.widget.SearchView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.searchView(): android.widget.SearchView = searchView({})
-public inline fun Context.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
-    ctx ->
-    val view = android.widget.SearchView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.searchView(): android.widget.SearchView = searchView({})
-public inline fun Activity.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
-    ctx ->
-    val view = android.widget.SearchView(ctx)
     view.init()
     view
 }
@@ -728,60 +809,6 @@ public inline fun ViewManager.switch(inlineOptions(InlineOption.ONLY_LOCAL_RETUR
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.tabHost(): android.widget.TabHost = tabHost({})
-public inline fun ViewManager.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
-    ctx ->
-    val view = android.widget.TabHost(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.tabHost(): android.widget.TabHost = tabHost({})
-public inline fun Context.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
-    ctx ->
-    val view = android.widget.TabHost(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.tabHost(): android.widget.TabHost = tabHost({})
-public inline fun Activity.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
-    ctx ->
-    val view = android.widget.TabHost(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.tabWidget(): android.widget.TabWidget = tabWidget({})
-public inline fun ViewManager.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
-    ctx ->
-    val view = android.widget.TabWidget(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.tabWidget(): android.widget.TabWidget = tabWidget({})
-public inline fun Context.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
-    ctx ->
-    val view = android.widget.TabWidget(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.tabWidget(): android.widget.TabWidget = tabWidget({})
-public inline fun Activity.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
-    ctx ->
-    val view = android.widget.TabWidget(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.textClock(): android.widget.TextClock = textClock({})
 public inline fun ViewManager.textClock(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TextClock.() -> Unit): android.widget.TextClock = addView<android.widget.TextClock> {
     ctx ->
@@ -800,64 +827,10 @@ public inline fun ViewManager.textView(inlineOptions(InlineOption.ONLY_LOCAL_RET
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.timePicker(): android.widget.TimePicker = timePicker({})
-public inline fun ViewManager.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
-    ctx ->
-    val view = android.widget.TimePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.timePicker(): android.widget.TimePicker = timePicker({})
-public inline fun Context.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
-    ctx ->
-    val view = android.widget.TimePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.timePicker(): android.widget.TimePicker = timePicker({})
-public inline fun Activity.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
-    ctx ->
-    val view = android.widget.TimePicker(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.toggleButton(): android.widget.ToggleButton = toggleButton({})
 public inline fun ViewManager.toggleButton(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ToggleButton.() -> Unit): android.widget.ToggleButton = addView<android.widget.ToggleButton> {
     ctx ->
     val view = android.widget.ToggleButton(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
-public inline fun ViewManager.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
-    ctx ->
-    val view = android.widget.TwoLineListItem(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
-public inline fun Context.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
-    ctx ->
-    val view = android.widget.TwoLineListItem(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
-public inline fun Activity.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
-    ctx ->
-    val view = android.widget.TwoLineListItem(ctx)
     view.init()
     view
 }
@@ -872,64 +845,10 @@ public inline fun ViewManager.videoView(inlineOptions(InlineOption.ONLY_LOCAL_RE
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
-public inline fun ViewManager.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
-    ctx ->
-    val view = android.widget.ViewFlipper(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
-public inline fun Context.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
-    ctx ->
-    val view = android.widget.ViewFlipper(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
-public inline fun Activity.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
-    ctx ->
-    val view = android.widget.ViewFlipper(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.zoomButton(): android.widget.ZoomButton = zoomButton({})
 public inline fun ViewManager.zoomButton(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ZoomButton.() -> Unit): android.widget.ZoomButton = addView<android.widget.ZoomButton> {
     ctx ->
     val view = android.widget.ZoomButton(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.zoomControls(): android.widget.ZoomControls = zoomControls({})
-public inline fun ViewManager.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
-    ctx ->
-    val view = android.widget.ZoomControls(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.zoomControls(): android.widget.ZoomControls = zoomControls({})
-public inline fun Context.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
-    ctx ->
-    val view = android.widget.ZoomControls(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.zoomControls(): android.widget.ZoomControls = zoomControls({})
-public inline fun Activity.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: android.widget.ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
-    ctx ->
-    val view = android.widget.ZoomControls(ctx)
     view.init()
     view
 }
@@ -962,6 +881,33 @@ public inline fun Activity.appWidgetHostView(inlineOptions(InlineOption.ONLY_LOC
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
+public inline fun ViewManager.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
+    ctx ->
+    val view = _GestureOverlayView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
+public inline fun Context.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
+    ctx ->
+    val view = _GestureOverlayView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.gestureOverlayView(): android.gesture.GestureOverlayView = gestureOverlayView({})
+public inline fun Activity.gestureOverlayView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GestureOverlayView.() -> Unit): android.gesture.GestureOverlayView = addView<android.gesture.GestureOverlayView> {
+    ctx ->
+    val view = _GestureOverlayView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.fragmentTabHost(): android.support.v4.app.FragmentTabHost = fragmentTabHost({})
 public inline fun ViewManager.fragmentTabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _FragmentTabHost.() -> Unit): android.support.v4.app.FragmentTabHost = addView<android.support.v4.app.FragmentTabHost> {
     ctx ->
@@ -989,82 +935,28 @@ public inline fun Activity.fragmentTabHost(inlineOptions(InlineOption.ONLY_LOCAL
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.viewPager(): android.support.v4.view.ViewPager = viewPager({})
-public inline fun ViewManager.viewPager(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewPager.() -> Unit): android.support.v4.view.ViewPager = addView<android.support.v4.view.ViewPager> {
+public inline fun ViewManager.nestedScrollView(): android.support.v4.widget.NestedScrollView = nestedScrollView({})
+public inline fun ViewManager.nestedScrollView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _NestedScrollView.() -> Unit): android.support.v4.widget.NestedScrollView = addView<android.support.v4.widget.NestedScrollView> {
     ctx ->
-    val view = _ViewPager(ctx)
+    val view = _NestedScrollView(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun Context.viewPager(): android.support.v4.view.ViewPager = viewPager({})
-public inline fun Context.viewPager(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewPager.() -> Unit): android.support.v4.view.ViewPager = addView<android.support.v4.view.ViewPager> {
+public inline fun Context.nestedScrollView(): android.support.v4.widget.NestedScrollView = nestedScrollView({})
+public inline fun Context.nestedScrollView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _NestedScrollView.() -> Unit): android.support.v4.widget.NestedScrollView = addView<android.support.v4.widget.NestedScrollView> {
     ctx ->
-    val view = _ViewPager(ctx)
+    val view = _NestedScrollView(ctx)
     view.init()
     view
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.viewPager(): android.support.v4.view.ViewPager = viewPager({})
-public inline fun Activity.viewPager(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewPager.() -> Unit): android.support.v4.view.ViewPager = addView<android.support.v4.view.ViewPager> {
+public inline fun Activity.nestedScrollView(): android.support.v4.widget.NestedScrollView = nestedScrollView({})
+public inline fun Activity.nestedScrollView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _NestedScrollView.() -> Unit): android.support.v4.widget.NestedScrollView = addView<android.support.v4.widget.NestedScrollView> {
     ctx ->
-    val view = _ViewPager(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.drawerLayout(): android.support.v4.widget.DrawerLayout = drawerLayout({})
-public inline fun ViewManager.drawerLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DrawerLayout.() -> Unit): android.support.v4.widget.DrawerLayout = addView<android.support.v4.widget.DrawerLayout> {
-    ctx ->
-    val view = _DrawerLayout(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.drawerLayout(): android.support.v4.widget.DrawerLayout = drawerLayout({})
-public inline fun Context.drawerLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DrawerLayout.() -> Unit): android.support.v4.widget.DrawerLayout = addView<android.support.v4.widget.DrawerLayout> {
-    ctx ->
-    val view = _DrawerLayout(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.drawerLayout(): android.support.v4.widget.DrawerLayout = drawerLayout({})
-public inline fun Activity.drawerLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DrawerLayout.() -> Unit): android.support.v4.widget.DrawerLayout = addView<android.support.v4.widget.DrawerLayout> {
-    ctx ->
-    val view = _DrawerLayout(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.slidingPaneLayout(): android.support.v4.widget.SlidingPaneLayout = slidingPaneLayout({})
-public inline fun ViewManager.slidingPaneLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SlidingPaneLayout.() -> Unit): android.support.v4.widget.SlidingPaneLayout = addView<android.support.v4.widget.SlidingPaneLayout> {
-    ctx ->
-    val view = _SlidingPaneLayout(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.slidingPaneLayout(): android.support.v4.widget.SlidingPaneLayout = slidingPaneLayout({})
-public inline fun Context.slidingPaneLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SlidingPaneLayout.() -> Unit): android.support.v4.widget.SlidingPaneLayout = addView<android.support.v4.widget.SlidingPaneLayout> {
-    ctx ->
-    val view = _SlidingPaneLayout(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.slidingPaneLayout(): android.support.v4.widget.SlidingPaneLayout = slidingPaneLayout({})
-public inline fun Activity.slidingPaneLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SlidingPaneLayout.() -> Unit): android.support.v4.widget.SlidingPaneLayout = addView<android.support.v4.widget.SlidingPaneLayout> {
-    ctx ->
-    val view = _SlidingPaneLayout(ctx)
+    val view = _NestedScrollView(ctx)
     view.init()
     view
 }
@@ -1124,6 +1016,33 @@ public inline fun Activity.linearLayoutCompatSupport(inlineOptions(InlineOption.
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.searchViewSupport(): android.support.v7.widget.SearchView = searchViewSupport({})
+public inline fun ViewManager.searchViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SearchViewSupport.() -> Unit): android.support.v7.widget.SearchView = addView<android.support.v7.widget.SearchView> {
+    ctx ->
+    val view = _SearchViewSupport(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.searchViewSupport(): android.support.v7.widget.SearchView = searchViewSupport({})
+public inline fun Context.searchViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SearchViewSupport.() -> Unit): android.support.v7.widget.SearchView = addView<android.support.v7.widget.SearchView> {
+    ctx ->
+    val view = _SearchViewSupport(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.searchViewSupport(): android.support.v7.widget.SearchView = searchViewSupport({})
+public inline fun Activity.searchViewSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SearchViewSupport.() -> Unit): android.support.v7.widget.SearchView = addView<android.support.v7.widget.SearchView> {
+    ctx ->
+    val view = _SearchViewSupport(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.toolbarSupport(): android.support.v7.widget.Toolbar = toolbarSupport({})
 public inline fun ViewManager.toolbarSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ToolbarSupport.() -> Unit): android.support.v7.widget.Toolbar = addView<android.support.v7.widget.Toolbar> {
     ctx ->
@@ -1146,60 +1065,6 @@ public inline fun Activity.toolbarSupport(): android.support.v7.widget.Toolbar =
 public inline fun Activity.toolbarSupport(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ToolbarSupport.() -> Unit): android.support.v7.widget.Toolbar = addView<android.support.v7.widget.Toolbar> {
     ctx ->
     val view = _ToolbarSupport(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.webView(): android.webkit.WebView = webView({})
-public inline fun ViewManager.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
-    ctx ->
-    val view = _WebView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.webView(): android.webkit.WebView = webView({})
-public inline fun Context.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
-    ctx ->
-    val view = _WebView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.webView(): android.webkit.WebView = webView({})
-public inline fun Activity.webView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _WebView.() -> Unit): android.webkit.WebView = addView<android.webkit.WebView> {
-    ctx ->
-    val view = _WebView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
-public inline fun ViewManager.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
-    ctx ->
-    val view = _AbsoluteLayout(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
-public inline fun Context.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
-    ctx ->
-    val view = _AbsoluteLayout(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.absoluteLayout(): android.widget.AbsoluteLayout = absoluteLayout({})
-public inline fun Activity.absoluteLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _AbsoluteLayout.() -> Unit): android.widget.AbsoluteLayout = addView<android.widget.AbsoluteLayout> {
-    ctx ->
-    val view = _AbsoluteLayout(ctx)
     view.init()
     view
 }
@@ -1232,6 +1097,87 @@ public inline fun Activity.actionMenuView(inlineOptions(InlineOption.ONLY_LOCAL_
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.calendarView(): android.widget.CalendarView = calendarView({})
+public inline fun ViewManager.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
+    ctx ->
+    val view = _CalendarView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.calendarView(): android.widget.CalendarView = calendarView({})
+public inline fun Context.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
+    ctx ->
+    val view = _CalendarView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.calendarView(): android.widget.CalendarView = calendarView({})
+public inline fun Activity.calendarView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _CalendarView.() -> Unit): android.widget.CalendarView = addView<android.widget.CalendarView> {
+    ctx ->
+    val view = _CalendarView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.datePicker(): android.widget.DatePicker = datePicker({})
+public inline fun ViewManager.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
+    ctx ->
+    val view = _DatePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.datePicker(): android.widget.DatePicker = datePicker({})
+public inline fun Context.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
+    ctx ->
+    val view = _DatePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.datePicker(): android.widget.DatePicker = datePicker({})
+public inline fun Activity.datePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DatePicker.() -> Unit): android.widget.DatePicker = addView<android.widget.DatePicker> {
+    ctx ->
+    val view = _DatePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
+public inline fun ViewManager.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
+    ctx ->
+    val view = _DialerFilter(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
+public inline fun Context.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
+    ctx ->
+    val view = _DialerFilter(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.dialerFilter(): android.widget.DialerFilter = dialerFilter({})
+public inline fun Activity.dialerFilter(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _DialerFilter.() -> Unit): android.widget.DialerFilter = addView<android.widget.DialerFilter> {
+    ctx ->
+    val view = _DialerFilter(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.frameLayout(): android.widget.FrameLayout = frameLayout({})
 public inline fun ViewManager.frameLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _FrameLayout.() -> Unit): android.widget.FrameLayout = addView<android.widget.FrameLayout> {
     ctx ->
@@ -1254,33 +1200,6 @@ public inline fun Activity.frameLayout(): android.widget.FrameLayout = frameLayo
 public inline fun Activity.frameLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _FrameLayout.() -> Unit): android.widget.FrameLayout = addView<android.widget.FrameLayout> {
     ctx ->
     val view = _FrameLayout(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.gallery(): android.widget.Gallery = gallery({})
-public inline fun ViewManager.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
-    ctx ->
-    val view = _Gallery(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.gallery(): android.widget.Gallery = gallery({})
-public inline fun Context.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
-    ctx ->
-    val view = _Gallery(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.gallery(): android.widget.Gallery = gallery({})
-public inline fun Activity.gallery(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _Gallery.() -> Unit): android.widget.Gallery = addView<android.widget.Gallery> {
-    ctx ->
-    val view = _Gallery(ctx)
     view.init()
     view
 }
@@ -1313,33 +1232,6 @@ public inline fun Activity.gridLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETU
 }
 
 [suppress("NOTHING_TO_INLINE")]
-public inline fun ViewManager.gridView(): android.widget.GridView = gridView({})
-public inline fun ViewManager.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
-    ctx ->
-    val view = _GridView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Context.gridView(): android.widget.GridView = gridView({})
-public inline fun Context.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
-    ctx ->
-    val view = _GridView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
-public inline fun Activity.gridView(): android.widget.GridView = gridView({})
-public inline fun Activity.gridView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _GridView.() -> Unit): android.widget.GridView = addView<android.widget.GridView> {
-    ctx ->
-    val view = _GridView(ctx)
-    view.init()
-    view
-}
-
-[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.horizontalScrollView(): android.widget.HorizontalScrollView = horizontalScrollView({})
 public inline fun ViewManager.horizontalScrollView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _HorizontalScrollView.() -> Unit): android.widget.HorizontalScrollView = addView<android.widget.HorizontalScrollView> {
     ctx ->
@@ -1367,6 +1259,33 @@ public inline fun Activity.horizontalScrollView(inlineOptions(InlineOption.ONLY_
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
+public inline fun ViewManager.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
+    ctx ->
+    val view = _ImageSwitcher(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
+public inline fun Context.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
+    ctx ->
+    val view = _ImageSwitcher(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.imageSwitcher(): android.widget.ImageSwitcher = imageSwitcher({})
+public inline fun Activity.imageSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ImageSwitcher.() -> Unit): android.widget.ImageSwitcher = addView<android.widget.ImageSwitcher> {
+    ctx ->
+    val view = _ImageSwitcher(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.linearLayout(): android.widget.LinearLayout = linearLayout({})
 public inline fun ViewManager.linearLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _LinearLayout.() -> Unit): android.widget.LinearLayout = addView<android.widget.LinearLayout> {
     ctx ->
@@ -1389,6 +1308,33 @@ public inline fun Activity.linearLayout(): android.widget.LinearLayout = linearL
 public inline fun Activity.linearLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _LinearLayout.() -> Unit): android.widget.LinearLayout = addView<android.widget.LinearLayout> {
     ctx ->
     val view = _LinearLayout(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.numberPicker(): android.widget.NumberPicker = numberPicker({})
+public inline fun ViewManager.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
+    ctx ->
+    val view = _NumberPicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.numberPicker(): android.widget.NumberPicker = numberPicker({})
+public inline fun Context.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
+    ctx ->
+    val view = _NumberPicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.numberPicker(): android.widget.NumberPicker = numberPicker({})
+public inline fun Activity.numberPicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _NumberPicker.() -> Unit): android.widget.NumberPicker = addView<android.widget.NumberPicker> {
+    ctx ->
+    val view = _NumberPicker(ctx)
     view.init()
     view
 }
@@ -1475,6 +1421,87 @@ public inline fun Activity.scrollView(inlineOptions(InlineOption.ONLY_LOCAL_RETU
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.searchView(): android.widget.SearchView = searchView({})
+public inline fun ViewManager.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
+    ctx ->
+    val view = _SearchView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.searchView(): android.widget.SearchView = searchView({})
+public inline fun Context.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
+    ctx ->
+    val view = _SearchView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.searchView(): android.widget.SearchView = searchView({})
+public inline fun Activity.searchView(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _SearchView.() -> Unit): android.widget.SearchView = addView<android.widget.SearchView> {
+    ctx ->
+    val view = _SearchView(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.tabHost(): android.widget.TabHost = tabHost({})
+public inline fun ViewManager.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
+    ctx ->
+    val view = _TabHost(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.tabHost(): android.widget.TabHost = tabHost({})
+public inline fun Context.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
+    ctx ->
+    val view = _TabHost(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.tabHost(): android.widget.TabHost = tabHost({})
+public inline fun Activity.tabHost(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabHost.() -> Unit): android.widget.TabHost = addView<android.widget.TabHost> {
+    ctx ->
+    val view = _TabHost(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.tabWidget(): android.widget.TabWidget = tabWidget({})
+public inline fun ViewManager.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
+    ctx ->
+    val view = _TabWidget(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.tabWidget(): android.widget.TabWidget = tabWidget({})
+public inline fun Context.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
+    ctx ->
+    val view = _TabWidget(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.tabWidget(): android.widget.TabWidget = tabWidget({})
+public inline fun Activity.tabWidget(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TabWidget.() -> Unit): android.widget.TabWidget = addView<android.widget.TabWidget> {
+    ctx ->
+    val view = _TabWidget(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.tableLayout(): android.widget.TableLayout = tableLayout({})
 public inline fun ViewManager.tableLayout(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TableLayout.() -> Unit): android.widget.TableLayout = addView<android.widget.TableLayout> {
     ctx ->
@@ -1556,6 +1583,33 @@ public inline fun Activity.textSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RE
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.timePicker(): android.widget.TimePicker = timePicker({})
+public inline fun ViewManager.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
+    ctx ->
+    val view = _TimePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.timePicker(): android.widget.TimePicker = timePicker({})
+public inline fun Context.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
+    ctx ->
+    val view = _TimePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.timePicker(): android.widget.TimePicker = timePicker({})
+public inline fun Activity.timePicker(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TimePicker.() -> Unit): android.widget.TimePicker = addView<android.widget.TimePicker> {
+    ctx ->
+    val view = _TimePicker(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.toolbar(): android.widget.Toolbar = toolbar({})
 public inline fun ViewManager.toolbar(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _Toolbar.() -> Unit): android.widget.Toolbar = addView<android.widget.Toolbar> {
     ctx ->
@@ -1578,6 +1632,33 @@ public inline fun Activity.toolbar(): android.widget.Toolbar = toolbar({})
 public inline fun Activity.toolbar(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _Toolbar.() -> Unit): android.widget.Toolbar = addView<android.widget.Toolbar> {
     ctx ->
     val view = _Toolbar(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
+public inline fun ViewManager.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
+    ctx ->
+    val view = _TwoLineListItem(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
+public inline fun Context.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
+    ctx ->
+    val view = _TwoLineListItem(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.twoLineListItem(): android.widget.TwoLineListItem = twoLineListItem({})
+public inline fun Activity.twoLineListItem(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _TwoLineListItem.() -> Unit): android.widget.TwoLineListItem = addView<android.widget.TwoLineListItem> {
+    ctx ->
+    val view = _TwoLineListItem(ctx)
     view.init()
     view
 }
@@ -1610,6 +1691,33 @@ public inline fun Activity.viewAnimator(inlineOptions(InlineOption.ONLY_LOCAL_RE
 }
 
 [suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
+public inline fun ViewManager.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
+    ctx ->
+    val view = _ViewFlipper(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
+public inline fun Context.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
+    ctx ->
+    val view = _ViewFlipper(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.viewFlipper(): android.widget.ViewFlipper = viewFlipper({})
+public inline fun Activity.viewFlipper(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewFlipper.() -> Unit): android.widget.ViewFlipper = addView<android.widget.ViewFlipper> {
+    ctx ->
+    val view = _ViewFlipper(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
 public inline fun ViewManager.viewSwitcher(): android.widget.ViewSwitcher = viewSwitcher({})
 public inline fun ViewManager.viewSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewSwitcher.() -> Unit): android.widget.ViewSwitcher = addView<android.widget.ViewSwitcher> {
     ctx ->
@@ -1632,6 +1740,33 @@ public inline fun Activity.viewSwitcher(): android.widget.ViewSwitcher = viewSwi
 public inline fun Activity.viewSwitcher(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ViewSwitcher.() -> Unit): android.widget.ViewSwitcher = addView<android.widget.ViewSwitcher> {
     ctx ->
     val view = _ViewSwitcher(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun ViewManager.zoomControls(): android.widget.ZoomControls = zoomControls({})
+public inline fun ViewManager.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
+    ctx ->
+    val view = _ZoomControls(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Context.zoomControls(): android.widget.ZoomControls = zoomControls({})
+public inline fun Context.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
+    ctx ->
+    val view = _ZoomControls(ctx)
+    view.init()
+    view
+}
+
+[suppress("NOTHING_TO_INLINE")]
+public inline fun Activity.zoomControls(): android.widget.ZoomControls = zoomControls({})
+public inline fun Activity.zoomControls(inlineOptions(InlineOption.ONLY_LOCAL_RETURN) init: _ZoomControls.() -> Unit): android.widget.ZoomControls = addView<android.widget.ZoomControls> {
+    ctx ->
+    val view = _ZoomControls(ctx)
     view.init()
     view
 }


### PR DESCRIPTION
One thing that's bugged me with Anko has been in cases where it generates DSL for ViewGroups using ViewGroup.LayoutParams instead of a more specific subclass even though one is available. I updated the method that pulls the LayoutParams node out to search up a ViewGroup's inheritance tree to find the nearest `generateLayoutParams()` method and use that method's return type to determine the correct LayoutParams implementation.

One side effect is that you can no longer use AbsoluteLayout.LayoutParams in the `absoluteLayout` DSL, since AbsoluteLayout's `generateLayoutParams()` method seems to return a vanilla ViewGroup.LayoutParams instance for some reason. I don't see this as a loss, however; AbsoluteLayout has been deprecated for a long time and you probably shouldn't be using it anyway.