### PR TITLE
Fix getter error messages

### DIFF
--- a/dsl/static/src/Other.kt
+++ b/dsl/static/src/Other.kt
@@ -47,11 +47,11 @@ public val Int.opaque: Int
 
 /* SECTION CUSTOM VIEW PROPERTIES */
 public var View.backgroundColor: Int
-    get() = throw AnkoException("'padding' property does not have a getter")
+    get() = throw AnkoException("'backgroundColor' property does not have a getter")
     set(value) {this.setBackgroundColor(value)}
 
 public var View.backgroundResource: Int
-    get() = throw AnkoException("'padding' property does not have a getter")
+    get() = throw AnkoException("'backgroundResource' property does not have a getter")
     set(value) {
         this.setBackgroundResource(value)
     }


### PR DESCRIPTION
Seems like copy-and-paste errors for a couple of the `getter` properties.

Fixed to use the correct names