### PR TITLE
Add property without getter TextView.gravity.

### DIFF
--- a/dsl/props/properties_without_getters.txt
+++ b/dsl/props/properties_without_getters.txt
@@ -13,6 +13,7 @@ android.widget.TextView.maxEms
 android.widget.TextView.singleLine
 android.widget.TextView.marqueeRepeatLimit
 android.widget.TextView.cursorVisible
+android.widget.TextView.gravity
 android.widget.ImageView.imageURI
 android.widget.ImageView.imageBitmap
 android.widget.RelativeLayout.gravity

--- a/dsl/testData/functional/sdk15/PropertyTest.kt
+++ b/dsl/testData/functional/sdk15/PropertyTest.kt
@@ -58,6 +58,10 @@ public var android.widget.TextView.cursorVisible: Boolean
     get() = throw AnkoException("'android.widget.TextView.cursorVisible' property does not have a getter")
     set(v) = setCursorVisible(v)
 
+public var android.widget.TextView.gravity: Int
+    get() = throw AnkoException("'android.widget.TextView.gravity' property does not have a getter")
+    set(v) = setGravity(v)
+
 public var android.widget.ImageView.imageURI: android.net.Uri?
     get() = throw AnkoException("'android.widget.ImageView.imageURI' property does not have a getter")
     set(v) = setImageURI(v)

--- a/dsl/testData/functional/sdk19/PropertyTest.kt
+++ b/dsl/testData/functional/sdk19/PropertyTest.kt
@@ -22,6 +22,10 @@ public var android.widget.TextView.singleLine: Boolean
     get() = throw AnkoException("'android.widget.TextView.singleLine' property does not have a getter")
     set(v) = setSingleLine(v)
 
+public var android.widget.TextView.gravity: Int
+    get() = throw AnkoException("'android.widget.TextView.gravity' property does not have a getter")
+    set(v) = setGravity(v)
+
 public var android.widget.ImageView.imageURI: android.net.Uri?
     get() = throw AnkoException("'android.widget.ImageView.imageURI' property does not have a getter")
     set(v) = setImageURI(v)

--- a/dsl/testData/functional/sdk21/PropertyTest.kt
+++ b/dsl/testData/functional/sdk21/PropertyTest.kt
@@ -30,6 +30,10 @@ public var android.widget.TextView.singleLine: Boolean
     get() = throw AnkoException("'android.widget.TextView.singleLine' property does not have a getter")
     set(v) = setSingleLine(v)
 
+public var android.widget.TextView.gravity: Int
+    get() = throw AnkoException("'android.widget.TextView.gravity' property does not have a getter")
+    set(v) = setGravity(v)
+
 public var android.widget.LinearLayout.gravity: Int
     get() = throw AnkoException("'android.widget.LinearLayout.gravity' property does not have a getter")
     set(v) = setGravity(v)

--- a/dsl/testData/functional/sdk23/PropertyTest.kt
+++ b/dsl/testData/functional/sdk23/PropertyTest.kt
@@ -22,6 +22,10 @@ public var android.widget.TextView.singleLine: Boolean
     get() = throw AnkoException("'android.widget.TextView.singleLine' property does not have a getter")
     set(v) = setSingleLine(v)
 
+public var android.widget.TextView.gravity: Int
+    get() = throw AnkoException("'android.widget.TextView.gravity' property does not have a getter")
+    set(v) = setGravity(v)
+
 public var android.widget.ImageView.imageURI: android.net.Uri?
     get() = throw AnkoException("'android.widget.ImageView.imageURI' property does not have a getter")
     set(v) = setImageURI(v)


### PR DESCRIPTION
As the title says.
Right now, when using `gravity` inside a textView block, it sets the layout params gravity.
With this modification, there is now 2 different gravity properties:

```java
textView {
   text = "Hello, world"
   gravity = Gravity.CENTER // text gravity
}.lparams {
   gravity = Gravity.RIGHT // layout gravity
}
```