### PR TITLE
Bring ImageView.imageResource property back.

### DIFF
--- a/dsl/props/properties_without_getters.txt
+++ b/dsl/props/properties_without_getters.txt
@@ -13,6 +13,7 @@ android.widget.TextView.maxEms
 android.widget.TextView.singleLine
 android.widget.TextView.marqueeRepeatLimit
 android.widget.TextView.cursorVisible
+android.widget.ImageView.imageResource
 android.widget.ImageView.imageURI
 android.widget.ImageView.imageBitmap
 android.widget.RelativeLayout.gravity

--- a/dsl/testData/functional/sdk15/PropertyTest.kt
+++ b/dsl/testData/functional/sdk15/PropertyTest.kt
@@ -58,6 +58,10 @@ public var android.widget.TextView.cursorVisible: Boolean
     get() = throw AnkoException("'android.widget.TextView.cursorVisible' property does not have a getter")
     set(v) = setCursorVisible(v)
 
+public var android.widget.ImageView.imageResource: Int
+    get() = throw AnkoException("'android.widget.ImageView.imageResource' property does not have a getter")
+    set(v) = setImageResource(v)
+
 public var android.widget.ImageView.imageURI: android.net.Uri?
     get() = throw AnkoException("'android.widget.ImageView.imageURI' property does not have a getter")
     set(v) = setImageURI(v)

--- a/dsl/testData/functional/sdk19/PropertyTest.kt
+++ b/dsl/testData/functional/sdk19/PropertyTest.kt
@@ -22,6 +22,10 @@ public var android.widget.TextView.singleLine: Boolean
     get() = throw AnkoException("'android.widget.TextView.singleLine' property does not have a getter")
     set(v) = setSingleLine(v)
 
+public var android.widget.ImageView.imageResource: Int
+    get() = throw AnkoException("'android.widget.ImageView.imageResource' property does not have a getter")
+    set(v) = setImageResource(v)
+
 public var android.widget.ImageView.imageURI: android.net.Uri?
     get() = throw AnkoException("'android.widget.ImageView.imageURI' property does not have a getter")
     set(v) = setImageURI(v)

--- a/dsl/testData/functional/sdk21/PropertyTest.kt
+++ b/dsl/testData/functional/sdk21/PropertyTest.kt
@@ -1,3 +1,7 @@
+public var android.widget.ImageView.imageResource: Int
+    get() = throw AnkoException("'android.widget.ImageView.imageResource' property does not have a getter")
+    set(v) = setImageResource(v)
+
 public var android.widget.ImageView.imageURI: android.net.Uri?
     get() = throw AnkoException("'android.widget.ImageView.imageURI' property does not have a getter")
     set(v) = setImageURI(v)

--- a/dsl/testData/functional/sdk23/PropertyTest.kt
+++ b/dsl/testData/functional/sdk23/PropertyTest.kt
@@ -22,6 +22,10 @@ public var android.widget.TextView.singleLine: Boolean
     get() = throw AnkoException("'android.widget.TextView.singleLine' property does not have a getter")
     set(v) = setSingleLine(v)
 
+public var android.widget.ImageView.imageResource: Int
+    get() = throw AnkoException("'android.widget.ImageView.imageResource' property does not have a getter")
+    set(v) = setImageResource(v)
+
 public var android.widget.ImageView.imageURI: android.net.Uri?
     get() = throw AnkoException("'android.widget.ImageView.imageURI' property does not have a getter")
     set(v) = setImageURI(v)


### PR DESCRIPTION
ImageView.imageResource property somehow gone missing after tests automation/generation process.