### PR TITLE
[fix] Fix unavailable jetbrains repository

### DIFF
--- a/update_dependencies_idea.xml
+++ b/update_dependencies_idea.xml
@@ -93,7 +93,7 @@
         <attribute name="version"/>
         <attribute name="bin" default="true"/>
         <attribute name="src" default="true"/>
-        <attribute name="server" default="http://repository.jetbrains.com/remote-repos"/>
+        <attribute name="server" default="https://repo1.maven.org/maven2"/>
         <attribute name="jar.name.base" default="@{lib}-@{version}"/>
         <attribute name="target.jar.name.base" default="@{jar.name.base}"/>
         <attribute name="path" default="@{prefix}/@{lib}/@{version}/@{jar.name.base}"/>


### PR DESCRIPTION
Jetbrains repository server does not works and dependencies updating fails with error:
```
BUILD FAILED
P:\android\projects\anko\anko-jetbrains-alt\update_dependencies.xml:29: The following error occurred while executing this line:
P:\android\projects\anko\anko-jetbrains-alt\update_dependencies_idea.xml:141: The following error occurred while executing this line:
P:\android\projects\anko\anko-jetbrains-alt\update_dependencies_idea.xml:104: Can't get http://repository.jetbrains.com/remote-repos/net/sf/proguard/proguard-base/5.1/proguard-base-5.1.jar to P:\android\projects\anko\anko-jetbrains-alt\dependencies\download\proguard-base-5.1.jar
```
So this way the repository server url was replaced by maven